### PR TITLE
DesktopApplications Provider Runner Config

### DIFF
--- a/internal/providers/desktopapplications/activate.go
+++ b/internal/providers/desktopapplications/activate.go
@@ -9,7 +9,7 @@ import (
 // app2unit firefox-developer-edition.desktop:new-private-window
 
 func Activate(sid uint32, identifier, action string) {
-	cmd := exec.Command("app2unit", identifier)
+	cmd := exec.Command(config.Runner, identifier)
 
 	err := cmd.Start()
 	if err != nil {

--- a/internal/providers/desktopapplications/config.go
+++ b/internal/providers/desktopapplications/config.go
@@ -7,6 +7,7 @@ import (
 type Config struct {
 	common.Config           `koanf:",squash"`
 	Locale                  string `koanf:"locale" desc:"to overwrite systems locale" default:""`
+	Runner                  string `koanf:"runner" desc:"program to use during process spawning" default:"app2unit"`
 	ShowActions             bool   `koanf:"show_actions" desc:"include application actions, f.e. 'New Private Window' for Firefox" default:"false"`
 	ShowGeneric             bool   `koanf:"show_generic" desc:"include generic info when show_actions is true" default:"false"`
 	PrioritizeNew           bool   `koanf:"prioritize_new" desc:"prioritize freshly installed applications" default:"false"`
@@ -18,6 +19,7 @@ var config *Config
 func loadConfig() {
 	config = &Config{
 		Config:                  common.Config{},
+		Runner:                  "app2unit",
 		ShowActions:             false,
 		ShowGeneric:             false,
 		PrioritizeNew:           false,


### PR DESCRIPTION
Introduced a config option for users that prefer an alternate runner to app2unit.
This creates a config field called "runner" where an enduser can specify the program used to start an app.
This functions similarly to Walker's AppLaunchPrefix config. (probably)