### PR TITLE
feat: Add comprehensive Nix integration with Home Manager and NixOS modules

### DIFF
--- a/NIX.md
+++ b/NIX.md
@@ -1,0 +1,268 @@
+# Elephant Nix Integration
+
+This document describes how to use Elephant with Nix, including Home Manager and NixOS modules.
+
+## Quick Installation
+
+### Using Nix Profile
+
+```bash
+# Install elephant with all providers
+nix profile install github:abenz1267/elephant#elephant-with-providers
+
+# Setup providers (run once)
+elephant-setup
+
+# Start elephant service
+elephant --debug
+```
+
+### Using Nix Run (temporary)
+
+```bash
+# Run elephant temporarily
+nix run github:abenz1267/elephant#elephant-with-providers
+
+# In another terminal, setup and test
+elephant-setup
+elephant listproviders
+```
+
+## Home Manager Integration
+
+Add elephant to your Home Manager configuration:
+
+### Basic Configuration
+
+```nix
+{
+  # In your home.nix or equivalent
+  imports = [ 
+    inputs.elephant.homeManagerModules.default 
+  ];
+
+  programs.elephant = {
+    enable = true;
+    autoStart = true;  # Start with user session
+    debug = false;     # Set to true for debugging
+  };
+}
+```
+
+### Advanced Configuration
+
+```nix
+{
+  programs.elephant = {
+    enable = true;
+    autoStart = true;
+    debug = false;
+    
+    # Select specific providers
+    providers = [
+      "files"
+      "desktopapplications" 
+      "calc"
+      "runner"
+      "clipboard"
+    ];
+    
+    # Custom elephant configuration
+    config = {
+      providers = {
+        files = {
+          min_score = 50;
+          icon = "folder";
+        };
+        desktopapplications = {
+          launch_prefix = "uwsm app --";
+          min_score = 60;
+        };
+        calc = {
+          icon = "accessories-calculator";
+        };
+      };
+    };
+  };
+}
+```
+
+### Available Providers
+
+- `files` - File search and management
+- `desktopapplications` - Desktop application launcher  
+- `calc` - Calculator and unit conversion
+- `runner` - Command runner
+- `clipboard` - Clipboard history management
+- `symbols` - Symbols and emojis
+- `websearch` - Web search integration
+- `menus` - Custom menu system
+- `providerlist` - Provider listing and management
+
+### Service Management
+
+When `autoStart = true`, elephant runs as a systemd user service:
+
+```bash
+# Service status
+systemctl --user status elephant
+
+# Start/stop manually
+systemctl --user start elephant
+systemctl --user stop elephant
+
+# View logs  
+journalctl --user -u elephant -f
+```
+
+## NixOS Integration
+
+For system-wide installation on NixOS:
+
+```nix
+{
+  # In your configuration.nix
+  imports = [ 
+    inputs.elephant.nixosModules.default 
+  ];
+
+  services.elephant = {
+    enable = true;
+    debug = false;
+    
+    # Custom system config
+    config = {
+      # Global elephant configuration
+    };
+  };
+}
+```
+
+## Flake Input Setup
+
+Add elephant to your flake inputs:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    
+    # Add elephant input
+    elephant = {
+      url = "github:abenz1267/elephant";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, home-manager, elephant, ... }: {
+    # Your configuration here
+  };
+}
+```
+
+## Available Packages
+
+- `elephant` - Just the elephant binary
+- `elephant-providers` - Just the provider plugins
+- `elephant-with-providers` - Complete installation (default)
+
+## Usage Examples
+
+### Query Providers
+
+```bash
+# List all providers
+elephant listproviders
+
+# Query files
+elephant query "files;Documents;5;false"
+
+# Search applications
+elephant query "desktopapplications;firefox;3;false"
+
+# Calculator
+elephant query "calc;2+2;1;false"
+
+# Symbols/emojis
+elephant query "symbols;heart;5;false"
+```
+
+### API Integration
+
+Elephant provides a Protocol Buffer API over Unix sockets for building custom launchers:
+
+```bash
+# Socket location
+/tmp/elephant.sock
+
+# Protocol definitions
+# See pkg/pb/ directory for .proto files
+```
+
+## Development
+
+### Building from Source
+
+```bash
+# Clone and build
+git clone https://github.com/abenz1267/elephant
+cd elephant
+
+# Build with Nix
+nix build
+
+# Development shell
+nix develop
+
+# Build and test providers
+nix develop -c ./build-providers.sh
+```
+
+### Contributing
+
+See the main README.md for contribution guidelines.
+
+## Troubleshooting
+
+### Plugin Compatibility Issues
+
+If you see "plugin was built with a different version" errors:
+
+1. Use the Nix packages (they ensure compatibility)
+2. Or rebuild everything in the same environment:
+   ```bash
+   nix develop -c bash -c "
+     go build -o ~/.local/bin/elephant cmd/elephant.go
+     ./build-providers.sh
+   "
+   ```
+
+### Service Issues
+
+```bash
+# Check service status
+systemctl --user status elephant
+
+# View logs
+journalctl --user -u elephant -f
+
+# Restart service
+systemctl --user restart elephant
+```
+
+### Providers Not Loading
+
+```bash
+# Check providers directory
+ls -la ~/.config/elephant/providers/
+
+# Run setup again
+elephant-setup
+
+# Check elephant config
+cat ~/.config/elephant/elephant.toml
+```

--- a/build-providers.sh
+++ b/build-providers.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Building elephant providers..."
+
+# Create providers directory
+mkdir -p ~/.config/elephant/providers
+
+# Available providers
+PROVIDERS=(
+  "files"
+  "desktopapplications" 
+  "calc"
+  "runner"
+  "clipboard"
+  "symbols"
+  "websearch"
+  "menus"
+  "providerlist"
+)
+
+echo "Building providers: ${PROVIDERS[@]}"
+
+for provider in "${PROVIDERS[@]}"; do
+  if [[ -d "./internal/providers/$provider" ]]; then
+    echo "Building $provider..."
+    go build -buildmode=plugin -o ~/.config/elephant/providers/$provider.so ./internal/providers/$provider
+    echo "✓ Built $provider.so"
+  else
+    echo "⚠ Provider $provider not found, skipping"
+  fi
+done
+
+echo ""
+echo "Providers built successfully!"
+echo "Run 'elephant listproviders' to see installed providers"
+echo "Run 'elephant --debug' to start the service"

--- a/flake.lock
+++ b/flake.lock
@@ -2,23 +2,39 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753345091,
-        "narHash": "sha256-CdX2Rtvp5I8HGu9swBmYuq+ILwRxpXdJwlpg8jvN4tU=",
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3ff0e34b1383648053bba8ed03f201d3466f90c9",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,20 +1,206 @@
 {
-  description = "Elephant Dev Shell";
+  description = ''
+    Elephant - a powerful data provider service and backend for building custom application launchers and desktop utilities.
+  '';
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default-linux";
+  };
 
-  outputs = { self, nixpkgs }:
-    let
-      system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
-    in {
-      devShells.${system}.default = pkgs.mkShell {
+  outputs = {
+    self,
+    nixpkgs,
+    systems,
+    ...
+  }: let
+    inherit (nixpkgs) lib;
+    eachSystem = f:
+      lib.genAttrs (import systems)
+      (system: f nixpkgs.legacyPackages.${system});
+  in {
+    formatter = eachSystem (pkgs: pkgs.alejandra);
+
+    devShells = eachSystem (pkgs: {
+      default = pkgs.mkShell {
         name = "elephant-dev-shell";
-
+        inputsFrom = [self.packages.${pkgs.system}.elephant];
         buildInputs = with pkgs; [
           go
           gcc
+          protobuf
+          protoc-gen-go
         ];
       };
+    });
+
+    packages = eachSystem (pkgs: {
+      default = self.packages.${pkgs.system}.elephant-with-providers;
+      
+      # Main elephant binary
+      elephant = pkgs.buildGoModule {
+        pname = "elephant";
+        version = "0.1.0";
+        
+        src = ./.;
+        
+        vendorHash = "sha256-bx6/ww7jE8VxDgSLVB12PeXGgxd3k/Brfjhl3qSJBL4=";
+        
+        buildInputs = with pkgs; [
+          protobuf
+        ];
+        
+        nativeBuildInputs = with pkgs; [
+          protoc-gen-go
+        ];
+        
+        # Build from cmd/elephant.go
+        subPackages = [ "cmd" ];
+        
+        # Rename the binary from cmd to elephant
+        postInstall = ''
+          mv $out/bin/cmd $out/bin/elephant
+        '';
+
+        meta = with lib; {
+          description = "Powerful data provider service and backend for building custom application launchers";
+          homepage = "https://github.com/abenz1267/elephant";
+          license = licenses.gpl3Only;
+          maintainers = [];
+          platforms = platforms.linux;
+        };
+      };
+      
+      # Providers package - builds all providers with same Go toolchain  
+      elephant-providers = pkgs.buildGoModule {
+        pname = "elephant-providers";
+        version = "0.1.0";
+        
+        src = ./.;
+        
+        vendorHash = "sha256-bx6/ww7jE8VxDgSLVB12PeXGgxd3k/Brfjhl3qSJBL4=";
+        
+        nativeBuildInputs = with pkgs; [
+          protobuf
+          protoc-gen-go
+        ];
+        
+        # Override the default build process
+        buildPhase = ''
+          runHook preBuild
+          
+          # Available providers
+          PROVIDERS=(
+            "files"
+            "desktopapplications" 
+            "calc"
+            "runner"
+            "clipboard"
+            "symbols"
+            "websearch"
+            "menus"
+            "providerlist"
+          )
+          
+          echo "Building elephant providers..."
+          
+          for provider in "''${PROVIDERS[@]}"; do
+            if [[ -d "./internal/providers/$provider" ]]; then
+              echo "Building $provider provider..."
+              go build -buildmode=plugin -o "$provider.so" ./internal/providers/$provider
+              echo "✓ Built $provider.so"
+            else
+              echo "⚠ Provider $provider not found, skipping"
+            fi
+          done
+          
+          runHook postBuild
+        '';
+        
+        installPhase = ''
+          runHook preInstall
+          
+          mkdir -p $out/lib/elephant/providers
+          
+          # Copy all built .so files
+          for so_file in *.so; do
+            if [[ -f "$so_file" ]]; then
+              cp "$so_file" "$out/lib/elephant/providers/"
+              echo "Installed provider: $so_file"
+            fi
+          done
+          
+          runHook postInstall
+        '';
+        
+        meta = with lib; {
+          description = "Elephant providers (Go plugins)";
+          homepage = "https://github.com/abenz1267/elephant";
+          license = licenses.gpl3Only;
+          platforms = platforms.linux;
+        };
+      };
+      
+      # Combined package with elephant + providers
+      elephant-with-providers = pkgs.stdenv.mkDerivation {
+        pname = "elephant-with-providers";
+        version = "0.1.0";
+        
+        dontUnpack = true;
+        
+        buildInputs = [
+          self.packages.${pkgs.system}.elephant
+          self.packages.${pkgs.system}.elephant-providers
+        ];
+        
+        installPhase = ''
+          mkdir -p $out/bin $out/lib/elephant
+          
+          # Copy elephant binary
+          cp ${self.packages.${pkgs.system}.elephant}/bin/elephant $out/bin/
+          
+          # Copy providers
+          cp -r ${self.packages.${pkgs.system}.elephant-providers}/lib/elephant/providers $out/lib/elephant/
+          
+          # Create setup script
+          cat > $out/bin/elephant-setup <<EOF
+#!/usr/bin/env bash
+set -e
+
+echo "🐘 Setting up Elephant providers..."
+
+# Create config directory
+mkdir -p ~/.config/elephant/providers
+
+# Copy providers to user config
+cp $out/lib/elephant/providers/*.so ~/.config/elephant/providers/
+
+echo "✅ Elephant providers installed to ~/.config/elephant/providers/"
+echo ""
+echo "🚀 Usage:"
+echo "  elephant --debug    # Start elephant service"
+echo "  elephant listproviders  # List installed providers"
+EOF
+          chmod +x $out/bin/elephant-setup
+        '';
+        
+        meta = with lib; {
+          description = "Elephant with all providers (complete installation)";
+          homepage = "https://github.com/abenz1267/elephant";
+          license = licenses.gpl3Only;
+          platforms = platforms.linux;
+        };
+      };
+    });
+
+    homeManagerModules = {
+      default = self.homeManagerModules.elephant;
+      elephant = import ./nix/modules/home-manager.nix self;
     };
+
+    nixosModules = {
+      default = self.nixosModules.elephant;
+      elephant = import ./nix/modules/nixos.nix self;
+    };
+  };
 }

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+echo "🐘 Installing Elephant with all providers..."
+
+# Ensure directories exist
+mkdir -p ~/.local/bin
+mkdir -p ~/.config/elephant/providers
+
+echo "📦 Building elephant..."
+nix develop -c go build -o ~/.local/bin/elephant cmd/elephant.go
+
+echo "🔌 Building providers..."
+nix develop -c ./build-providers.sh
+
+echo "✅ Installation complete!"
+echo ""
+echo "🚀 Usage:"
+echo "  Add ~/.local/bin to your PATH if not already there:"
+echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+echo ""
+echo "  Start elephant service:"
+echo "    elephant --debug"
+echo ""
+echo "  Query providers (in another terminal):"
+echo "    elephant listproviders"
+echo "    elephant query \"files;Documents;5;false\""
+echo "    elephant query \"desktopapplications;chrome;3;false\""
+echo "    elephant query \"calc;2+2;1;false\""
+echo ""
+echo "📖 Check the README for more usage examples and API documentation."

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -1,0 +1,118 @@
+flake:
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.elephant;
+  
+  # Available providers
+  providerOptions = {
+    files = "File search and management";
+    desktopapplications = "Desktop application launcher";
+    calc = "Calculator and unit conversion";
+    runner = "Command runner";
+    clipboard = "Clipboard history management";
+    symbols = "Symbols and emojis";
+    websearch = "Web search integration";
+    menus = "Custom menu system";
+    providerlist = "Provider listing and management";
+  };
+in
+{
+  options.programs.elephant = {
+    enable = mkEnableOption "Elephant launcher backend";
+
+    package = mkOption {
+      type = types.package;
+      default = flake.packages.${pkgs.system}.elephant-with-providers;
+      defaultText = literalExpression "flake.packages.\${pkgs.system}.elephant-with-providers";
+      description = "The elephant package to use.";
+    };
+
+    providers = mkOption {
+      type = types.listOf (types.enum (attrNames providerOptions));
+      default = attrNames providerOptions;
+      example = [ "files" "desktopapplications" "calc" ];
+      description = ''
+        List of providers to enable. Available providers:
+        ${concatStringsSep "\n" (mapAttrsToList (name: desc: "  - ${name}: ${desc}") providerOptions)}
+      '';
+    };
+
+    autoStart = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to automatically start elephant service with the session.";
+    };
+
+    debug = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable debug logging for elephant service.";
+    };
+
+    config = mkOption {
+      type = types.attrs;
+      default = {};
+      example = literalExpression ''
+        {
+          providers = {
+            files = {
+              min_score = 50;
+            };
+            desktopapplications = {
+              launch_prefix = "uwsm app --";
+            };
+          };
+        }
+      '';
+      description = "Elephant configuration as Nix attributes.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    # Install providers to user config
+    home.activation.elephantProviders = lib.hm.dag.entryAfter ["writeBoundary"] ''
+      $DRY_RUN_CMD mkdir -p $HOME/.config/elephant/providers
+      
+      # Copy enabled providers
+      ${concatStringsSep "\n" (map (provider: ''
+        if [[ -f "${cfg.package}/lib/elephant/providers/${provider}.so" ]]; then
+          $DRY_RUN_CMD cp "${cfg.package}/lib/elephant/providers/${provider}.so" "$HOME/.config/elephant/providers/"
+          $VERBOSE_ECHO "Installed elephant provider: ${provider}"
+        fi
+      '') cfg.providers)}
+    '';
+
+    # Generate elephant config file
+    xdg.configFile."elephant/elephant.toml" = mkIf (cfg.config != {}) {
+      source = (pkgs.formats.toml {}).generate "elephant.toml" cfg.config;
+    };
+
+    # Auto-start service if enabled
+    systemd.user.services.elephant = mkIf cfg.autoStart {
+      Unit = {
+        Description = "Elephant launcher backend";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/bin/elephant ${optionalString cfg.debug "--debug"}";
+        Restart = "on-failure";
+        RestartSec = 1;
+        
+        # Clean up socket on stop
+        ExecStopPost = "${pkgs.coreutils}/bin/rm -f /tmp/elephant.sock";
+      };
+
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+    };
+  };
+}

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -1,0 +1,98 @@
+flake:
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.elephant;
+in
+{
+  options.services.elephant = {
+    enable = mkEnableOption "Elephant launcher backend system service";
+
+    package = mkOption {
+      type = types.package;
+      default = flake.packages.${pkgs.system}.elephant-with-providers;
+      defaultText = literalExpression "flake.packages.\${pkgs.system}.elephant-with-providers";
+      description = "The elephant package to use.";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "elephant";
+      description = "User under which elephant runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "elephant";
+      description = "Group under which elephant runs.";
+    };
+
+    debug = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable debug logging.";
+    };
+
+    config = mkOption {
+      type = types.attrs;
+      default = {};
+      description = "Elephant configuration as Nix attributes.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      description = "Elephant launcher backend user";
+      group = cfg.group;
+      isSystemUser = true;
+      home = "/var/lib/elephant";
+      createHome = true;
+    };
+
+    users.groups.${cfg.group} = {};
+
+    # Install providers system-wide
+    environment.etc."xdg/elephant/providers" = {
+      source = "${cfg.package}/lib/elephant/providers";
+    };
+
+    # System-wide config
+    environment.etc."xdg/elephant/elephant.toml" = mkIf (cfg.config != {}) {
+      source = (pkgs.formats.toml {}).generate "elephant.toml" cfg.config;
+    };
+
+    systemd.services.elephant = {
+      description = "Elephant launcher backend";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${cfg.package}/bin/elephant ${optionalString cfg.debug "--debug"}";
+        Restart = "on-failure";
+        RestartSec = 1;
+        
+        # Security settings
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [ "/var/lib/elephant" "/tmp" ];
+        
+        # Clean up socket on stop
+        ExecStopPost = "${pkgs.coreutils}/bin/rm -f /tmp/elephant.sock";
+      };
+
+      environment = {
+        HOME = "/var/lib/elephant";
+      };
+    };
+
+    # Add elephant to system packages
+    environment.systemPackages = [ cfg.package ];
+  };
+}


### PR DESCRIPTION
This PR adds comprehensive Nix integration to Elephant, including:

## 🏗️ Enhanced Flake Structure
- **elephant**: Main binary package  
- **elephant-providers**: All 9 providers built with same Go toolchain
- **elephant-with-providers**: Complete installation (default)

## 🏠 Home Manager Module ()
- Auto-installs providers to 
- Configurable provider selection
- Optional auto-start with systemd user service  
- Custom configuration support

## 🖥️ NixOS Module ()
- System-wide installation option
- System service management
- Global configuration

## 🔧 Problem Solved
Resolves Go plugin compatibility issues by ensuring elephant binary and all providers are built with the same Go toolchain.

## 📦 All 9 Providers Supported
files, desktopapplications, calc, runner, clipboard, symbols, websearch, menus, providerlist

## 📖 Documentation & Scripts
- : Comprehensive Nix usage guide
- : Manual provider building script
- : Simple installation script
- Home Manager and NixOS module examples

## 🚀 Usage Examples

**Home Manager:**


**Direct Installation:**
🐘 Setting up Elephant providers...
✅ Elephant providers installed to ~/.config/elephant/providers/

🚀 Usage:
  elephant --debug    # Start elephant service
  elephant listproviders  # List installed providers

This provides a much better installation experience than manual Go plugin building and makes Elephant easily accessible to the Nix ecosystem.