### PR TITLE
feat(home-manager): add ConditionEnvironment "WAYLAND_DISPLAY"

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -109,6 +109,7 @@ in
         Description = "Elephant launcher backend";
         After = [ "graphical-session-pre.target" ];
         PartOf = [ "graphical-session.target" ];
+        ConditionEnvironment = "WAYLAND_DISPLAY";
       };
 
       Service = {


### PR DESCRIPTION
load service after "WAYLAND_DISPLAY" 
fixes: #25 