### PR TITLE
Fix duplicate aliases

### DIFF
--- a/cmd/elephant/elephant.go
+++ b/cmd/elephant/elephant.go
@@ -58,7 +58,7 @@ func main() {
 			},
 			{
 				Name:    "listproviders",
-				Aliases: []string{"d"},
+				Aliases: []string{"l"},
 				Usage:   "lists all installed providers",
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					logger := slog.New(slog.DiscardHandler)


### PR DESCRIPTION
The aliases for `listproviders` and `generatedoc` are both set to `d`.

https://github.com/abenz1267/elephant/blob/4fcdcb8e2c9269de1ce4d767bd4b51548415b468/cmd/elephant/elephant.go#L96-L108