### PR TITLE
feat(home-manager) - delay start of walker service for uwsm sessions

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -107,7 +107,7 @@ in
     systemd.user.services.elephant = mkIf cfg.installService {
       Unit = {
         Description = "Elephant launcher backend";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
         ConditionEnvironment = "WAYLAND_DISPLAY";
       };


### PR DESCRIPTION
WAYLAND_DISPLAY isn't available after graphical-session-pre.target for uwsm managed wayland sessions, instead move to after graphical-session.target.

Fixes #37.