### PR TITLE
Add /v2 suffix to module path

### DIFF
--- a/cmd/elephant/elephant.go
+++ b/cmd/elephant/elephant.go
@@ -13,11 +13,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/abenz1267/elephant/internal/comm"
-	"github.com/abenz1267/elephant/internal/comm/client"
-	"github.com/abenz1267/elephant/internal/providers"
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
+	"github.com/abenz1267/elephant/v2/internal/comm"
+	"github.com/abenz1267/elephant/v2/internal/comm/client"
+	"github.com/abenz1267/elephant/v2/internal/providers"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
 	"github.com/adrg/xdg"
 	"github.com/urfave/cli/v3"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/abenz1267/elephant
+module github.com/abenz1267/elephant/v2
 
 go 1.25.0
 

--- a/internal/comm/client/activate.go
+++ b/internal/comm/client/activate.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/internal/comm/client/menu.go
+++ b/internal/comm/client/menu.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"net"
 
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/internal/comm/client/query.go
+++ b/internal/comm/client/query.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/internal/comm/comm.go
+++ b/internal/comm/comm.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/abenz1267/elephant/internal/comm/handlers"
+	"github.com/abenz1267/elephant/v2/internal/comm/handlers"
 )
 
 // connection id

--- a/internal/comm/handlers/activationrequesthandler.go
+++ b/internal/comm/handlers/activationrequesthandler.go
@@ -7,8 +7,8 @@ import (
 	"net"
 	"strings"
 
-	"github.com/abenz1267/elephant/internal/providers"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/providers"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/internal/comm/handlers/menurequesthandler.go
+++ b/internal/comm/handlers/menurequesthandler.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"net"
 
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/internal/comm/handlers/queryrequesthandler.go
+++ b/internal/comm/handlers/queryrequesthandler.go
@@ -13,8 +13,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/abenz1267/elephant/internal/providers"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/providers"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/internal/comm/handlers/subscriberequesthandler.go
+++ b/internal/comm/handlers/subscriberequesthandler.go
@@ -12,8 +12,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/abenz1267/elephant/internal/providers"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/providers"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/internal/providers/archlinuxpkgs/setup.go
+++ b/internal/providers/archlinuxpkgs/setup.go
@@ -15,9 +15,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
 var (

--- a/internal/providers/bluetooth/setup.go
+++ b/internal/providers/bluetooth/setup.go
@@ -11,10 +11,10 @@ import (
 
 	_ "embed"
 
-	"github.com/abenz1267/elephant/internal/comm/handlers"
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/comm/handlers"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
 var (

--- a/internal/providers/calc/setup.go
+++ b/internal/providers/calc/setup.go
@@ -18,10 +18,10 @@ import (
 
 	_ "embed"
 
-	"github.com/abenz1267/elephant/internal/comm/handlers"
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/comm/handlers"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
 var (

--- a/internal/providers/clipboard/setup.go
+++ b/internal/providers/clipboard/setup.go
@@ -21,9 +21,9 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
 var (

--- a/internal/providers/desktopapplications/activate.go
+++ b/internal/providers/desktopapplications/activate.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/common/history"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/common/history"
 )
 
 const (

--- a/internal/providers/desktopapplications/doc.go
+++ b/internal/providers/desktopapplications/doc.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/abenz1267/elephant/internal/util"
+	"github.com/abenz1267/elephant/v2/internal/util"
 )
 
 func PrintDoc() {

--- a/internal/providers/desktopapplications/files.go
+++ b/internal/providers/desktopapplications/files.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/abenz1267/elephant/internal/comm/handlers"
-	"github.com/abenz1267/elephant/pkg/common"
+	"github.com/abenz1267/elephant/v2/internal/comm/handlers"
+	"github.com/abenz1267/elephant/v2/pkg/common"
 	"github.com/adrg/xdg"
 	"github.com/charlievieth/fastwalk"
 	"github.com/fsnotify/fsnotify"

--- a/internal/providers/desktopapplications/query.go
+++ b/internal/providers/desktopapplications/query.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/common/history"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/common/history"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
 func Query(conn net.Conn, query string, _ bool, exact bool) []*pb.QueryResponse_Item {

--- a/internal/providers/desktopapplications/setup.go
+++ b/internal/providers/desktopapplications/setup.go
@@ -11,8 +11,8 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/common/history"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/common/history"
 )
 
 type DesktopFile struct {

--- a/internal/providers/files/activate.go
+++ b/internal/providers/files/activate.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/abenz1267/elephant/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/common"
 )
 
 const (

--- a/internal/providers/files/query.go
+++ b/internal/providers/files/query.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
 func Query(conn net.Conn, query string, _ bool, exact bool) []*pb.QueryResponse_Item {

--- a/internal/providers/files/setup.go
+++ b/internal/providers/files/setup.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
 	"github.com/djherbis/times"
 	"github.com/fsnotify/fsnotify"
 )

--- a/internal/providers/load.go
+++ b/internal/providers/load.go
@@ -11,8 +11,8 @@ import (
 	"slices"
 	"sync"
 
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 	"github.com/charlievieth/fastwalk"
 )
 

--- a/internal/providers/menus/setup.go
+++ b/internal/providers/menus/setup.go
@@ -11,11 +11,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/abenz1267/elephant/internal/comm/handlers"
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/common/history"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/comm/handlers"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/common/history"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
 var (

--- a/internal/providers/providerlist/setup.go
+++ b/internal/providers/providerlist/setup.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/abenz1267/elephant/internal/providers"
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/providers"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
 var (

--- a/internal/providers/runner/setup.go
+++ b/internal/providers/runner/setup.go
@@ -17,10 +17,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/common/history"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/common/history"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 	"github.com/charlievieth/fastwalk"
 )
 

--- a/internal/providers/symbols/setup.go
+++ b/internal/providers/symbols/setup.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/common/history"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/common/history"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
 var (

--- a/internal/providers/todo/setup.go
+++ b/internal/providers/todo/setup.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
 var (

--- a/internal/providers/unicode/setup.go
+++ b/internal/providers/unicode/setup.go
@@ -11,10 +11,10 @@ import (
 
 	_ "embed"
 
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/common/history"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/common/history"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
 var (

--- a/internal/providers/websearch/setup.go
+++ b/internal/providers/websearch/setup.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/abenz1267/elephant/internal/comm/handlers"
-	"github.com/abenz1267/elephant/internal/util"
-	"github.com/abenz1267/elephant/pkg/common"
-	"github.com/abenz1267/elephant/pkg/common/history"
-	"github.com/abenz1267/elephant/pkg/pb/pb"
+	"github.com/abenz1267/elephant/v2/internal/comm/handlers"
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/common/history"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
 var (

--- a/internal/util/doc.go
+++ b/internal/util/doc.go
@@ -7,8 +7,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/abenz1267/elephant/internal/providers"
-	"github.com/abenz1267/elephant/pkg/common"
+	"github.com/abenz1267/elephant/v2/internal/providers"
+	"github.com/abenz1267/elephant/v2/pkg/common"
 )
 
 func GenerateDoc() {

--- a/pkg/common/history/history.go
+++ b/pkg/common/history/history.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/abenz1267/elephant/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/common"
 )
 
 type HistoryData struct {


### PR DESCRIPTION
This PR includes a set of changes to append /v2 suffix to all module paths in the repository.

Modules having version 2 or greater should have a module path with a major version suffix according to Golang's convention. [1][2]

The proposed changes are just for following the standard and no functional changes are intended.

References:
[1] https://go.dev/ref/mod#module-path
[2] https://go.dev/blog/v2-go-modules
