### PR TITLE
I would like to be able to search on Exec too

### DIFF
--- a/internal/providers/desktopapplications/query.go
+++ b/internal/providers/desktopapplications/query.go
@@ -257,7 +257,7 @@ func calcScore(q string, d *Data, exact bool) (string, int32, []int32, int32, bo
 
 	toSearch := []string{d.Name}
 	if !config.OnlySearchTitle {
-		toSearch = []string{d.Name, d.Parent, d.GenericName, strings.Join(d.Keywords, ","), d.Comment}
+		toSearch = []string{d.Name, d.Exec, d.Parent, d.GenericName, strings.Join(d.Keywords, ","), d.Comment}
 	}
 
 	for k, v := range toSearch {


### PR DESCRIPTION
Basically, some programs (like baobab in my case) have an exec that has a name that it's different enough from the normal name that I think we should allow searching with it.