### PR TITLE
feat: allow blacklisting desktop entry paths

### DIFF
--- a/internal/providers/desktopapplications/files.go
+++ b/internal/providers/desktopapplications/files.go
@@ -85,7 +85,7 @@ func walkFunction(path string, d fs.DirEntry, err error) error {
 	}
 
 	if filepath.Ext(path) == ".desktop" {
-		check := strings.TrimSuffix(filepath.Base(path), ".desktop")
+		check := strings.TrimSuffix(path, ".desktop")
 
 		for _, v := range br {
 			if v.MatchString(check) {


### PR DESCRIPTION
It would be nice to be able to blacklist desktop entries based on their parent directories. I did it the simplest way i saw how, but its a breaking change. Idk whether you're comfortable with that or not since it is a relatively new feature. If not I'd be happy to add a new config option to support this