### PR TITLE
fix: build error and missing windows provider

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
         # Main elephant binary
         elephant = pkgs.buildGo125Module {
           pname = "elephant";
-          version = builtins.readFile ./cmd/elephant/version.txt;
+          version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
 
           src = ./.;
 
@@ -78,11 +78,15 @@
         # Providers package - builds all providers with same Go toolchain
         elephant-providers = pkgs.buildGo125Module rec {
           pname = "elephant-providers";
-          version = builtins.readFile ./cmd/elephant/version.txt;
+          version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
 
           src = ./.;
 
           vendorHash = "sha256-uwcGPmie44rfq9qCOXO3WjJXiLxQxNPmKQYbG9a22/c=";
+
+          buildInputs = with pkgs; [
+            wayland
+          ];
 
           nativeBuildInputs = with pkgs; [
             protobuf
@@ -165,7 +169,7 @@
         # Combined package with elephant + providers
         elephant-with-providers = pkgs.stdenv.mkDerivation {
           pname = "elephant-with-providers";
-          version = builtins.readFile ./cmd/elephant/version.txt;
+          version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
 
           dontUnpack = true;
 
@@ -185,16 +189,16 @@
           '';
 
           postFixup = ''
-             wrapProgram $out/bin/elephant \
-            	  --prefix PATH : ${
-                 lib.makeBinPath (
-                   with pkgs;
-                   [
-                     wl-clipboard
-                     libqalculate
-                   ]
-                 )
-               }
+            wrapProgram $out/bin/elephant \
+                  --prefix PATH : ${
+                    lib.makeBinPath (
+                      with pkgs;
+                      [
+                        wl-clipboard
+                        libqalculate
+                      ]
+                    )
+                  }
           '';
 
           meta = with lib; {

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -21,6 +21,7 @@ with lib; let
     todo = "Todo list";
     unicode = "Unicode symbol search";
     bluetooth = "Basic Bluetooth management";
+    windows = "Find and focus windows";
   };
 in {
   options.programs.elephant = {
@@ -89,7 +90,7 @@ in {
           source = (pkgs.formats.toml {}).generate "elephant.toml" cfg.config;
         };
       }
-      // 
+      //
       # Generate provider files
       builtins.listToAttrs
       (map


### PR DESCRIPTION
Related to #83 and #84 

I have tested this with Niri and it works but on KDE it crashes. I don't think this is a nix related error but could be wrong. I don't have Hyprland setup for testing

<details><summary>Elephant Output In KDE</summary>
<p>


```shell
elephant
2025/10/21 03:33:46 INFO config "runprefix autodetect"="systemd-run --user --scope"
2025/10/21 03:33:46 INFO menus config="using default config"
2025/10/21 03:33:46 INFO websearch config="using default config"
2025/10/21 03:33:46 INFO providers loaded=websearch
2025/10/21 03:33:46 INFO symbols config="using default config"
2025/10/21 03:33:46 INFO clipboard config="using default config"
2025/10/21 03:33:46 INFO runner config="using default config"
2025/10/21 03:33:46 INFO symbols symbols/emojis=1948 time=10.79007ms
2025/10/21 03:33:46 INFO providers loaded=symbols
2025/10/21 03:33:46 ERROR runner load="stat /home/riaru/.local/state/nix/profile/bin: no such file or directory"
2025/10/21 03:33:46 ERROR runner load="stat /home/riaru/.local/state/nix/profile/bin: no such file or directory"
2025/10/21 03:33:46 ERROR runner load="stat /nix/var/nix/profiles/default/bin: no such file or directory"
2025/10/21 03:33:46 INFO bluetooth config="using default config"
2025/10/21 03:33:46 INFO bluetooth loaded=171.923µs
2025/10/21 03:33:46 INFO providers loaded=bluetooth
2025/10/21 03:33:46 INFO calc config="using default config"
2025/10/21 03:33:46 INFO providers loaded=calc
2025/10/21 03:33:46 INFO runner executables=1663 time=9.258685ms
2025/10/21 03:33:46 INFO providers loaded=runner
2025/10/21 03:33:46 INFO clipboard history=100 time=13.957833ms
2025/10/21 03:33:46 INFO providers loaded=clipboard
2025/10/21 03:33:46 INFO desktopapplications config="using default config"
2025/10/21 03:33:46 INFO files config="using default config"
2025/10/21 03:33:46 INFO providerlist config="using default config"
2025/10/21 03:33:46 INFO providers loaded=providerlist
2025/10/21 03:33:46 INFO unicode config="using default config"
2025/10/21 03:33:46 INFO todo config="using default config"
2025/10/21 03:33:46 INFO providers loaded=todo
2025/10/21 03:33:46 INFO unicode loaded=8.324264ms
2025/10/21 03:33:46 INFO providers loaded=unicode
2025/10/21 03:33:46 INFO desktopapplications files=262 time=29.438614ms
2025/10/21 03:33:46 INFO desktopapplications watcher_dirs=105
2025/10/21 03:33:46 INFO desktopapplications watcher=started
2025/10/21 03:33:46 INFO desktopapplications "desktop files"=262 time=29.592703ms
2025/10/21 03:33:46 INFO providers loaded=desktopapplications
2025/10/21 03:33:46 INFO providers loaded=menus
2025/10/21 03:33:46 INFO elephant startup=59.400891ms
2025/10/21 03:33:46 INFO comm listen=starting
2025/10/21 03:33:46 INFO files time=86.171187ms
2025/10/21 03:33:46 INFO providers loaded=files
Wayland compositor does not support wlr-foreign-toplevel-management protocol
2025/10/21 03:33:46 ERROR windows init="failed to initialize window manager"
2025/10/21 03:33:46 INFO windows setup="retrying initWindowManager"
2025/10/21 03:33:47 INFO comm connection=new
2025/10/21 03:33:47 INFO comm connection=new
2025/10/21 03:33:47 INFO comm connection=new
2025/10/21 03:33:47 INFO subscription new=bluetooth
2025/10/21 03:33:47 INFO subscription new=menus
2025/10/21 03:33:47 INFO desktopapplications queryresult=85 time=39.5µs
2025/10/21 03:33:47 INFO providers results=50 time=255.908µs query=""
Wayland compositor does not support wlr-foreign-toplevel-management protocol
2025/10/21 03:33:47 ERROR windows init="failed to initialize window manager"
2025/10/21 03:33:47 INFO windows setup="retrying initWindowManager"
Wayland compositor does not support wlr-foreign-toplevel-management protocol
2025/10/21 03:33:48 ERROR windows init="failed to initialize window manager"
2025/10/21 03:33:48 INFO windows setup="retrying initWindowManager"
Wayland compositor does not support wlr-foreign-toplevel-management protocol
2025/10/21 03:33:49 ERROR windows init="failed to initialize window manager"
2025/10/21 03:33:49 INFO windows setup="retrying initWindowManager"
Wayland compositor does not support wlr-foreign-toplevel-management protocol
2025/10/21 03:33:50 ERROR windows init="failed to initialize window manager"
2025/10/21 03:33:50 INFO windows setup="retrying initWindowManager"
Wayland compositor does not support wlr-foreign-toplevel-management protocol
2025/10/21 03:33:51 ERROR windows init="failed to initialize window manager"
2025/10/21 03:33:51 INFO windows setup="retrying initWindowManager"
Wayland compositor does not support wlr-foreign-toplevel-management protocol
2025/10/21 03:33:52 ERROR windows init="failed to initialize window manager"
2025/10/21 03:33:52 INFO windows setup="retrying initWindowManager"
Wayland compositor does not support wlr-foreign-toplevel-management protocol
2025/10/21 03:33:53 ERROR windows init="failed to initialize window manager"
2025/10/21 03:33:53 INFO windows setup="retrying initWindowManager"
Wayland compositor does not support wlr-foreign-toplevel-management protocol
2025/10/21 03:33:54 ERROR windows init="failed to initialize window manager"
2025/10/21 03:33:54 INFO windows setup="retrying initWindowManager"
Wayland compositor does not support wlr-foreign-toplevel-management protocol
2025/10/21 03:33:55 ERROR windows init="failed to initialize window manager"
2025/10/21 03:33:55 INFO windows setup="retrying initWindowManager"
Wayland compositor does not support wlr-foreign-toplevel-management protocol
2025/10/21 03:33:56 ERROR windows init="failed to initialize window manager"
2025/10/21 03:33:56 INFO windows setup="retrying initWindowManager"
2025/10/21 03:33:57 ERROR windows setup="couldn't init window manager"
2025/10/21 03:33:57 INFO providers loaded=windows
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7f92bbac9f8a]

goroutine 532 [running]:
github.com/abenz1267/elephant/v2/internal/providers/windows.Icon()
        github.com/abenz1267/elephant/v2/internal/providers/windows/setup.go:217 +0xa
github.com/abenz1267/elephant/v2/internal/providers/providerlist.Query({0x9eff60?, 0xc00046e2a0?}, {0x0, 0x0}, 0x0?, 0x0)
        github.com/abenz1267/elephant/v2/internal/providers/providerlist/setup.go:110 +0x464
github.com/abenz1267/elephant/v2/internal/comm/handlers.(*QueryRequest).Handle.func2({0x0, 0x0}, 0x0?)
        github.com/abenz1267/elephant/v2/internal/comm/handlers/queryrequesthandler.go:132 +0x191
created by github.com/abenz1267/elephant/v2/internal/comm/handlers.(*QueryRequest).Handle in goroutine 531
        github.com/abenz1267/elephant/v2/internal/comm/handlers/queryrequesthandler.go:129 +0x4e8
```

</p>
</details> 