### PR TITLE
feat(nix): allow menus to be defined with nix modules

### DIFF
--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -23,6 +23,9 @@ with lib; let
     bookmarks = "Bookmarks management";
     unicode = "Unicode symbol search";
     bluetooth = "Basic Bluetooth management";
+    windows = "Find and focus windows";
+    snippets = "Find and paste text snippets";
+    nirisessions = "Define sets of apps to open and run them";
   };
 in {
   imports = [
@@ -79,85 +82,209 @@ in {
     };
 
     settings = mkOption {
-      description = ''
-        elephant/elephant.toml configuration as Nix attributes.
-        `elephant generatedoc` to view your installed version's options.
-      '';
-      default = {};
       type = types.submodule {
         freeformType = settingsFormat.type;
       };
-      example = ''
+      default = {};
+      example = literalExpression ''
         {
           auto_detect_launch_prefix = false;
         }
       '';
+      description = ''
+        elephant/elephant.toml run `elephant generatedoc` to view available options.
+      '';
     };
 
     provider = mkOption {
-      description = "Provider specific settings";
       type = types.attrsOf (types.submodule {
         options = {
+          # Generic Options
           settings = mkOption {
-            description = ''
-              Provider specific toml configuration as Nix attributes.
-              `elephant generatedoc` to view your installed providers version options.
-            '';
             type = types.submodule {
               freeformType = settingsFormat.type;
             };
             default = {};
+            description = ''
+              Provider specific toml configuration as Nix attributes. Run `elephant generatedoc` to view available options.
+            '';
+          };
+
+          # Menus Provider Settings
+          # provider.menus.toml
+          toml = mkOption {
+            type = types.attrsOf (types.submodule {
+              freeformType = settingsFormat.type;
+            });
+            example =
+              literalExpression
+              ''
+                {
+                  "bookmarks" = {
+                    name = "bookmarks";
+                    name_pretty = "Bookmarks";
+                    icon = "bookmark";
+                    global_search = true;
+                    action = "xdg-open %VALUE%";
+
+                    entries = [
+                      {
+                        text = "Walker";
+                        value = "https://github.com/abenz1267/walker";
+                      }
+                      {
+                        text = "Elephant";
+                        value = "https://github.com/abenz1267/elephant";
+                      }
+                      {
+                        text = "Drive";
+                        value = "https://drive.google.com";
+                      }
+                      {
+                        text = "Prime";
+                        value = "https://www.amazon.de/gp/video/storefront/";
+                      }
+                    ];
+                  };
+                }
+              '';
+            default = {};
+            description = "Declaratively define menus using TOML.";
+          };
+
+          # provider.menus.lua
+          lua = mkOption {
+            type = types.attrsOf types.lines;
+            default = {};
+            example = literalExpression ''
+              {
+                "luatest" = \'\'
+                  Name = "luatest"
+                  NamePretty = "Lua Test"
+                  Icon = "applications-other"
+                  Cache = true
+                  Action = "notify-send %VALUE%"
+                  HideFromProviderlist = false
+                  Description = "lua test menu"
+                  SearchName = true
+
+                  function GetEntries()
+                      local entries = {}
+                      local wallpaper_dir = "/home/andrej/Documents/ArchInstall/wallpapers"
+
+                      local handle = io.popen("find '" ..
+                          wallpaper_dir ..
+                          "' -maxdepth 1 -type f -name '*.jpg' -o -name '*.jpeg' -o -name '*.png' -o -name '*.gif' -o -name '*.bmp' -o -name '*.webp' 2>/dev/null")
+                      if handle then
+                          for line in handle:lines() do
+                              local filename = line:match("([^/]+)$")
+                              if filename then
+                                  table.insert(entries, {
+                                      Text = filename,
+                                      Subtext = "wallpaper",
+                                      Value = line,
+                                      Actions = {
+                                          up = "notify-send up",
+                                          down = "notify-send down",
+                                      },
+                                      -- Preview = line,
+                                      -- PreviewType = "file",
+                                      -- Icon = line
+                                  })
+                              end
+                          end
+                          handle:close()
+                      end
+
+                      return entries
+                  end
+                \'\';
+            '';
+            description = "Declaratively define menus using Lua.";
           };
         };
       });
       default = {};
-      example = ''
-        websearch.settings = {
-          entries = [
-            {
-              name = "NixOS Options";
-              url = "https://search.nixos.org/options?query=%TERM%";
-            }
-          ];
-        };
+      example = literalExpression ''
+        {
+          websearch.settings = {
+            entries = [
+              {
+                name = "NixOS Options";
+                url = "https://search.nixos.org/options?query=%TERM%";
+              }
+            ];
+          };
+        }
       '';
+      description = "Provider specific settings";
     };
   };
 
   config = mkIf cfg.enable {
     environment.systemPackages = [cfg.package];
 
-    # Install providers to system config
     environment.etc =
-      {
+      mkMerge
+      [
         # Generate elephant config
-        "xdg/elephant/elephant.toml" = mkIf (cfg.settings != {}) {
-          source = settingsFormat.generate "elephant.toml" cfg.settings;
-        };
-      }
-      # Generate provider files
-      // builtins.listToAttrs
-      (map
-        (
-          provider:
-            lib.nameValuePair
-            "xdg/elephant/providers/${provider}.so"
-            {
-              source = "${cfg.package}/lib/elephant/providers/${provider}.so";
-            }
-        )
-        cfg.providers)
-      # Generate provider configs
-      // (mapAttrs'
-        (
-          name: {settings, ...}:
-            lib.nameValuePair
-            "xdg/elephant/${name}.toml"
-            {
-              source = settingsFormat.generate "${name}.toml" settings;
-            }
-        )
-        cfg.provider);
+        {
+          "xdg/elephant/elephant.toml" = mkIf (cfg.settings != {}) {
+            source = settingsFormat.generate "elephant.toml" cfg.settings;
+          };
+        }
+
+        # Generate provider files
+        (builtins.listToAttrs
+          (map
+            (
+              provider:
+                lib.nameValuePair
+                "xdg/elephant/providers/${provider}.so"
+                {
+                  source = "${cfg.package}/lib/elephant/providers/${provider}.so";
+                }
+            )
+            cfg.providers))
+
+        # Generate provider configs
+        (mapAttrs'
+          (
+            name: {settings, ...}:
+              lib.nameValuePair
+              "xdg/elephant/${name}.toml"
+              {
+                source = settingsFormat.generate "${name}.toml" settings;
+              }
+          )
+          (lib.filterAttrs (n: v: v.settings != {}) cfg.provider))
+
+        (lib.mkIf (cfg.provider ? "menus")
+          # Generate TOML menu files
+          (mapAttrs'
+            (
+              name: value:
+                lib.nameValuePair
+                "xdg/elephant/menus/${name}.toml"
+                {
+                  source = settingsFormat.generate "${name}.toml" value;
+                }
+            )
+            cfg.provider.menus.toml))
+
+        # Generate Lua menu files
+        (lib.mkIf (cfg.provider ? "menus")
+          (mapAttrs'
+            (
+              name: value:
+                lib.nameValuePair
+                "xdg/elephant/menus/${name}.lua"
+                {
+                  text = value;
+                }
+            )
+            cfg.provider.menus.lua))
+      ];
 
     systemd.services.elephant = mkIf cfg.installService {
       description = "Elephant launcher backend";


### PR DESCRIPTION
This allows for menus to be defined using nix syntax using `provider.menus.toml` and `providers.menus.lua`

<details><summary>example</summary>
<p>

```nix
provider.menus = {
    toml = {
      bookmarks = {
        name = "bookmarks";
        name_pretty = "Bookmarks";
        icon = "bookmark";
        global_search = true;
        action = "xdg-open %VALUE%";

        entries = [
          {
            text = "Walker";
            value = "https://github.com/abenz1267/walker";
          }
          {
            text = "Elephant";
            value = "https://github.com/abenz1267/elephant";
          }
          {
            text = "Drive";
            value = "https://drive.google.com";
          }
          {
            text = "Prime";
            value = "https://www.amazon.de/gp/video/storefront/";
          }
        ];
      };
    };

    lua = {
      "luatest" = ''
        Name = "luatest"
        NamePretty = "Lua Test"
        Icon = "applications-other"
        Cache = true
        Action = "notify-send %VALUE%"
        HideFromProviderlist = false
        Description = "lua test menu"
        SearchName = true

        function GetEntries()
            local entries = {}
            local wallpaper_dir = "/mnt/nfs/riaru/Captures/anime-edits"

            local handle = io.popen("find '" ..
                wallpaper_dir ..
                "' -maxdepth 1 -type f -name '*.jpg' -o -name '*.jpeg' -o -name '*.png' -o -name '*.gif' -o -name '*.bmp' -o -name '*.webp' 2>/dev/null")
            if handle then
                for line in handle:lines() do
                    local filename = line:match("([^/]+)$")
                    if filename then
                        table.insert(entries, {
                            Text = filename,
                            Subtext = "wallpaper",
                            Value = line,
                            Actions = {
                                up = "notify-send up",
                                down = "notify-send down",
                            },
                            -- Preview = line,
                            -- PreviewType = "file",
                            -- Icon = line
                        })
                    end
                end
                handle:close()
            end

            return entries
        end
      '';
    };
};
```

```bash
lsd --tree
 .
├──  files.toml ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/files.toml
├──  menus
│   ├──  bookmarks.toml ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/menus/bookmarks.toml
│   ├──  luatest.lua ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/menus/luatest.lua
│   ├──  other.toml ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/menus/other.toml
│   └──  screenshots.toml ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/menus/screenshots.toml
├──  providers
│   ├──  bluetooth.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/bluetooth.so
│   ├──  bookmarks.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/bookmarks.so
│   ├──  calc.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/calc.so
│   ├──  clipboard.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/clipboard.so
│   ├──  desktopapplications.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/desktopapplications.so
│   ├──  files.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/files.so
│   ├──  menus.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/menus.so
│   ├──  nirisessions.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/nirisessions.so
│   ├──  providerlist.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/providerlist.so
│   ├──  runner.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/runner.so
│   ├──  snippets.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/snippets.so
│   ├──  symbols.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/symbols.so
│   ├──  todo.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/todo.so
│   ├──  unicode.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/unicode.so
│   ├──  websearch.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/websearch.so
│   └──  windows.so ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/providers/windows.so
└──  websearch.toml ⇒ /nix/store/z14l9bzwm5xxycp40n44wy83d6145jar-home-manager-files/.config/elephant/websearch.toml
```

</p>
</details> 
