### PR TITLE
feat(cmd): allow printing docs for a specific provider

### DIFF
--- a/cmd/elephant/elephant.go
+++ b/cmd/elephant/elephant.go
@@ -153,6 +153,11 @@ WantedBy=graphical-session.target
 				Name:    "generatedoc",
 				Aliases: []string{"d"},
 				Usage:   "generates a markdown documentation",
+				Arguments: []cli.Argument{
+					&cli.StringArg{
+						Name: "provider",
+					},
+				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					common.LoadGlobalConfig()
 
@@ -161,7 +166,7 @@ WantedBy=graphical-session.target
 
 					providers.Load(false)
 
-					util.GenerateDoc()
+					util.GenerateDoc(cmd.StringArg("provider"))
 					return nil
 				},
 			},

--- a/internal/util/doc.go
+++ b/internal/util/doc.go
@@ -11,19 +11,25 @@ import (
 	"github.com/abenz1267/elephant/v2/pkg/common"
 )
 
-func GenerateDoc() {
-	fmt.Println("# Elephant")
+func GenerateDoc(provider string) {
+	provider = strings.ToLower(provider)
+	
+	if provider == "" || provider == "elephant" {
+		fmt.Println("# Elephant")
 
-	fmt.Println("A service providing various datasources which can be triggered to perform actions.")
-	fmt.Println()
-	fmt.Println("Run `elephant -h` to get an overview of the available commandline flags and actions.")
+		fmt.Println("A service providing various datasources which can be triggered to perform actions.")
+		fmt.Println()
+		fmt.Println("Run `elephant -h` to get an overview of the available commandline flags and actions.")
 
-	fmt.Println("## Elephant Configuration")
+		fmt.Println("## Elephant Configuration")
 
-	PrintConfig(common.ElephantConfig{}, "elephant")
+		PrintConfig(common.ElephantConfig{}, "elephant")
+	}
 
-	fmt.Println("## Provider Configuration")
-
+	if provider == "" {
+		fmt.Println("## Provider Configuration")
+	}
+	
 	p := []providers.Provider{}
 
 	for _, v := range providers.Providers {
@@ -35,7 +41,9 @@ func GenerateDoc() {
 	})
 
 	for _, v := range p {
-		v.PrintDoc()
+		if provider == "" || provider == strings.ToLower(*v.Name) || provider == strings.ToLower(*v.NamePretty) {
+			v.PrintDoc()	
+		}
 	}
 }
 


### PR DESCRIPTION
The docs is pretty long and difficulty to search through. This will allows you to specify the provider you want. The syntax is `elephant d <provider name>`. When provider name is omitted the entire docs is printed

```bash
elephant d elephant | glow
2025/11/05 17:44:28 INFO elephant config="using default config"

   Elephant

  A service providing various datasources which can be triggered to perform
  actions.

  Run  elephant -h  to get an overview of the available commandline flags and
  actions.

  ## Elephant Configuration

   ~/.config/elephant/elephant.toml

  #### ElephantConfig

   Field                    │ Type     │ Default │ Description
  ──────────────────────────┼──────────┼─────────┼──────────────────────────
   auto_detect_launch_prefi │ bool     │ true    │ automatically detects
   x                        │          │         │ uwsm, app2unit or
                            │          │         │ systemd-run
   overload_local_env       │ bool     │ false   │ overloads the local env
   ignored_providers        │ []string │         │ providers to ignore
   git_on_demand            │ bool     │ true    │ sets up git repositories
                            │          │         │ on first query instead
                            │          │         │ of on start
```
```bash
elephant d bluetooth | glow
2025/11/05 17:44:35 INFO elephant config="using default config"

  ### Elephant Bluetooth

  Simple bluetooth management. Connect/Disconnect. Pair/Remove. Trust/Untrust.

  #### Requirements

  •  bluetoothctl

   ~/.config/elephant/bluetooth.toml

  #### Config

   Field               │ Type   │ Default             │ Description
  ─────────────────────┼────────┼─────────────────────┼─────────────────────
   icon                │ string │ depends on provider │ icon for provider
   min_score           │ int32  │ depends on provider │ minimum score for
                       │        │                     │ items to be
                       │        │                     │ displayed
   hide_from_providerl │ bool   │ false               │ hides a provider
   ist                 │        │                     │ from the
                       │        │                     │ providerlist
                       │        │                     │ provider. provider
                       │        │                     │ provider. 

```