### PR TITLE
fix(bluetooth): fix error from parsing bluetoothctl paired devices

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -199,6 +199,7 @@
                         wl-clipboard
                         libqalculate
                         imagemagick
+                        bluez
                       ]
                     )
                   }

--- a/internal/providers/bluetooth/setup.go
+++ b/internal/providers/bluetooth/setup.go
@@ -320,44 +320,46 @@ func getDevices() {
 	}
 
 	for v := range strings.Lines(string(out)) {
-		fields := strings.SplitN(v, " ", 3)
-		d := Device{
-			Name: strings.TrimSpace(fields[2]),
-			Mac:  fields[1],
-		}
-
-		cmd := exec.Command("bluetoothctl", "info", d.Mac)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			slog.Error(Name, "get info", err)
-		}
-
-		for l := range strings.Lines(string(out)) {
-			if strings.HasPrefix(strings.TrimSpace(l), "Icon") {
-				d.Icon = strings.TrimPrefix(strings.TrimSpace(l), "Icon: ")
+		if strings.Contains(v, "Device") {
+			fields := strings.SplitN(v, " ", 3)
+			d := Device{
+				Name: strings.TrimSpace(fields[2]),
+				Mac:  fields[1],
 			}
 
-			if strings.HasPrefix(strings.TrimSpace(l), "Paired") {
-				if strings.Contains(l, "yes") {
-					d.Paired = true
+			cmd := exec.Command("bluetoothctl", "info", d.Mac)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				slog.Error(Name, "get info", err)
+			}
+
+			for l := range strings.Lines(string(out)) {
+				if strings.HasPrefix(strings.TrimSpace(l), "Icon") {
+					d.Icon = strings.TrimPrefix(strings.TrimSpace(l), "Icon: ")
+				}
+
+				if strings.HasPrefix(strings.TrimSpace(l), "Paired") {
+					if strings.Contains(l, "yes") {
+						d.Paired = true
+					}
+				}
+
+				if strings.HasPrefix(strings.TrimSpace(l), "Connected") {
+					if strings.Contains(l, "yes") {
+						d.Connected = true
+					}
+				}
+
+				if strings.HasPrefix(strings.TrimSpace(l), "Trusted") {
+					if strings.Contains(l, "yes") {
+						d.Trusted = true
+					}
 				}
 			}
 
-			if strings.HasPrefix(strings.TrimSpace(l), "Connected") {
-				if strings.Contains(l, "yes") {
-					d.Connected = true
-				}
+			if d.Paired {
+				devices = append(devices, d)
 			}
-
-			if strings.HasPrefix(strings.TrimSpace(l), "Trusted") {
-				if strings.Contains(l, "yes") {
-					d.Trusted = true
-				}
-			}
-		}
-
-		if d.Paired {
-			devices = append(devices, d)
 		}
 	}
 }


### PR DESCRIPTION
The provider tries to parse non devices as devices causing a crash

<details><summary>Details</summary>
<p>


```bash
$ elephant
2025/11/05 18:08:30 INFO elephant config="using default config"
2025/11/05 18:08:30 INFO config "runprefix autodetect"="niri msg action spawn --"
2025/11/05 18:08:30 INFO menus config="using default config"
2025/11/05 18:08:30 INFO providers loaded=websearch
2025/11/05 18:08:30 INFO providers loaded=symbols
2025/11/05 18:08:30 INFO symbols config="using default config"
2025/11/05 18:08:30 INFO providers loaded=clipboard
2025/11/05 18:08:30 INFO clipboard config="using default config"
2025/11/05 18:08:30 INFO symbols symbols/emojis=1948 time=14.852725ms
2025/11/05 18:08:30 INFO providers loaded=runner
2025/11/05 18:08:30 INFO runner config="using default config"
2025/11/05 18:08:30 ERROR runner load="stat /home/riaru/.local/state/nix/profile/bin: no such file or directory"
2025/11/05 18:08:30 ERROR runner load="stat /home/riaru/.local/state/nix/profile/bin: no such file or directory"
2025/11/05 18:08:30 ERROR runner load="stat /nix/var/nix/profiles/default/bin: no such file or directory"
2025/11/05 18:08:30 INFO providers loaded=bluetooth
2025/11/05 18:08:30 INFO bluetooth config="using default config"
2025/11/05 18:08:30 INFO bluetooth loaded=118.66µs
2025/11/05 18:08:30 INFO runner executables=1709 time=8.354994ms
2025/11/05 18:08:30 INFO clipboard history=100 time=19.18797ms
2025/11/05 18:08:30 INFO providers loaded=calc
2025/11/05 18:08:30 INFO calc config="using default config"
2025/11/05 18:08:30 INFO providers loaded=desktopapplications
2025/11/05 18:08:30 INFO desktopapplications config="using default config"
2025/11/05 18:08:30 INFO providers loaded=bookmarks
2025/11/05 18:08:30 INFO bookmarks config="using default config"
2025/11/05 18:08:30 INFO providers loaded=files
2025/11/05 18:08:30 INFO desktopapplications files=270 time=20.930456ms
2025/11/05 18:08:30 INFO desktopapplications watcher_dirs=110
2025/11/05 18:08:30 INFO desktopapplications watcher=started
2025/11/05 18:08:30 INFO desktopapplications "desktop files"=270 time=21.141571ms
2025/11/05 18:08:30 INFO providers loaded=providerlist
2025/11/05 18:08:30 INFO providerlist config="using default config"
2025/11/05 18:08:30 INFO providers loaded=windows
2025/11/05 18:08:30 INFO windows config="using default config"
2025/11/05 18:08:30 INFO windows loaded=5.76106ms
2025/11/05 18:08:30 INFO providers loaded=unicode
2025/11/05 18:08:30 INFO unicode config="using default config"
2025/11/05 18:08:30 INFO unicode loaded=8.38506ms
2025/11/05 18:08:30 INFO providers loaded=nirisessions
2025/11/05 18:08:30 INFO nirisessions config="using default config"
2025/11/05 18:08:30 INFO providers loaded=snippets
2025/11/05 18:08:30 INFO snippets config="using default config"
2025/11/05 18:08:30 INFO providers loaded=todo
2025/11/05 18:08:30 INFO providers loaded=menus
2025/11/05 18:08:30 INFO elephant startup=142.958295ms
2025/11/05 18:08:30 INFO comm listen=starting
2025/11/05 18:08:30 INFO todo config="using default config"
2025/11/05 18:08:30 INFO files time=117.310291ms
2025/11/05 18:08:31 INFO comm connection=new
2025/11/05 18:08:31 INFO comm connection=new
2025/11/05 18:08:31 INFO comm connection=new
2025/11/05 18:08:31 INFO subscription new=bluetooth
2025/11/05 18:08:31 INFO subscription new=menus
2025/11/05 18:08:31 INFO desktopapplications queryresult=86 time=60.439µs
2025/11/05 18:08:31 INFO providers results=50 time=309.781µs query=""
2025/11/05 18:08:32 INFO providerlist queryresult=14 time=32.613µs
2025/11/05 18:08:32 INFO providers results=14 time=106.767µs query=""
2025/11/05 18:08:33 ERROR bluetooth "get info"="exit status 1"
panic: runtime error: index out of range [2] with length 2

goroutine 903 [running]:
github.com/abenz1267/elephant/v2/internal/providers/bluetooth.getDevices-range2(...)
        github.com/abenz1267/elephant/v2/internal/providers/bluetooth/setup.go:325
github.com/abenz1267/elephant/v2/internal/providers/bluetooth.getDevices.Lines.func2(...)
        strings/iter.go:27
github.com/abenz1267/elephant/v2/internal/providers/bluetooth.getDevices()
        github.com/abenz1267/elephant/v2/internal/providers/bluetooth/setup.go:322 +0xb52
github.com/abenz1267/elephant/v2/internal/providers/bluetooth.Query({0x10ad5e0?, 0xc000584150?}, {0x0, 0x0}, 0x0?, 0x0, 0x0?)
        github.com/abenz1267/elephant/v2/internal/providers/bluetooth/setup.go:206 +0x57
github.com/abenz1267/elephant/v2/internal/comm/handlers.(*QueryRequest).Handle.func2({0x0, 0x0}, 0x0?)
        github.com/abenz1267/elephant/v2/internal/comm/handlers/queryrequesthandler.go:154 +0x1c3
created by github.com/abenz1267/elephant/v2/internal/comm/handlers.(*QueryRequest).Handle in goroutine 902
        github.com/abenz1267/elephant/v2/internal/comm/handlers/queryrequesthandler.go:151 +0x613

```

```bash
$ bluetoothctl devices Paired
Device 88:03:4C:FE:66:EF Wireless Controller
[NEW] Media /org/bluez/hci0
        SupportedUUIDs: 0000110a-0000-1000-8000-00805f9b34fb
        SupportedUUIDs: 0000110b-0000-1000-8000-00805f9b34fb
```

</p>
</details> 

