### PR TITLE
Auto update vendor hash with gh actions

### DIFF
--- a/.github/workflows/update-vendor-hash.yml
+++ b/.github/workflows/update-vendor-hash.yml
@@ -1,0 +1,36 @@
+name: Update Vendor Hash
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "go.mod"
+      - "go.sum"
+
+jobs:
+  update-vendor-hash:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Update vendor hash
+        run: |
+          nix run nixpkgs#nix-update -- --flake --version=skip elephant 
+          nix run nixpkgs#nix-update -- --flake --version=skip elephant-providers
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(nix): update vendor hash"
+          title: "Update vendor hash"
+          body: "Automated vendor hash update"
+          branch: update-vendor-hash
+          delete-branch: true


### PR DESCRIPTION
This calculates and updates the vendor hash whenever go.mod or go.sum is modified. It then creates a pr with the changes

If you prefer you can change it to commit changes directly instead of creating a pr with the following
```yml
      - name: Commit Changes
        run: |
          git config user.name "github-actions[bot]"
          git config user.email "github-actions[bot]@users.noreply.github.com"
          git add -A
          git diff --quiet && git diff --staged --quiet || \
            (git commit -m "chore(nix): update vendor hash" && git push)
```