### PR TITLE
Update README with Markdown documentation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ Elephant uses a configuration directory structure:
 └── <provider>.toml      # Provider config
 ```
 
+Markdown documentation for configuring Elephant and its providers can be obtained using `elephant generatedoc`.
+
+Markdown documentation for configuring a specific provider can be obtained using `elephant generatedoc <provider>`, e.g. `elephant generatedoc unicode`.
+
 ## API & Integration
 
 ### Communication Protocol


### PR DESCRIPTION
This is a suggestion to add instructions for generating documentation for Elephant and its providers, after initially [struggling](https://github.com/basecamp/omarchy/discussions/2835#discussioncomment-15116991) to set it up (thanks @abenz1267 for the help).

Perhaps it could be presented even higher in the README? 

I would find it less confusing if the project's README, which is the entry point for many to learn more about this software, explained more clearly that one must rely on `elephant generatedoc` to learn how to configure Elephant and its providers.

Perhaps the language could be tweaked to make it clear that even the end-user who just wants to read the docs is supposed to use this `generatedoc` command (I initially assumed this would be more for those who are contributing to the code or developing their own providers, for instance).

Besides, would it be possible for this Markdown documentation to be available directly in GitHub for online viewing? It will allow those who haven't yet installed the program to understand in more detail what it does and how it can be configured.

These are just what I came across as I was familiarizing with Elephant, feel free to close if unhelpful. And thanks a lot for building this great resource.