### PR TITLE
fix: add 1Password provider to home-manager module

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -26,6 +26,7 @@ with lib; let
     windows = "Find and focus windows";
     snippets = "Find and paste text snippets";
     nirisessions = "Define sets of apps to open and run them";
+    "1password" = "Access your 1Password Vaults";
   };
 in {
   imports = [


### PR DESCRIPTION
The 1password provider was missing from the home-manager module.
Simply adding this line was enough to get it working on my NixOS machine :)
Thanks for the great project