### PR TITLE
feat(websearch): search suggestion and various reworks

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.so
 cmd/elephant/elephant
 tmp
+.direnv
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.so
 cmd/elephant/elephant
 tmp
-.direnv
 .vscode
+.direnv

--- a/flake.nix
+++ b/flake.nix
@@ -8,220 +8,221 @@
     systems.url = "github:nix-systems/default-linux";
   };
 
-  outputs =
-    {
-      self,
-      nixpkgs,
-      systems,
-      ...
-    }:
-    let
-      inherit (nixpkgs) lib;
-      eachSystem = f: lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
-    in
-    {
-      formatter = eachSystem (pkgs: pkgs.alejandra);
+  outputs = {
+    self,
+    nixpkgs,
+    systems,
+    ...
+  }: let
+    inherit (nixpkgs) lib;
+    eachSystem = f: lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+  in {
+    formatter = eachSystem (pkgs: pkgs.alejandra);
 
-      devShells = eachSystem (pkgs: {
-        default = pkgs.mkShell {
-          name = "elephant-dev-shell";
-          inputsFrom = [ self.packages.${pkgs.stdenv.system}.elephant ];
-          buildInputs = with pkgs; [
-            go
-            gcc
-            protobuf
-            protoc-gen-go
-          ];
+    devShells = eachSystem (pkgs: {
+      default = pkgs.mkShell {
+        name = "elephant-dev-shell";
+        inputsFrom = [self.packages.${pkgs.stdenv.system}.elephant];
+        buildInputs = with pkgs; [
+          go
+          air
+          gcc
+          protobuf
+          protoc-gen-go
+          wl-clipboard
+          libqalculate
+          imagemagick
+          bluez
+        ];
+      };
+    });
+
+    packages = eachSystem (pkgs: {
+      default = self.packages.${pkgs.stdenv.system}.elephant-with-providers;
+
+      # Main elephant binary
+      elephant = pkgs.buildGo125Module {
+        pname = "elephant";
+        version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
+
+        src = ./.;
+
+        vendorHash = "sha256-XYGh4ZXRly3MCPWse51eUMyjXqtHzKbPEyD0J8S/MDk=";
+
+        buildInputs = with pkgs; [
+          protobuf
+        ];
+
+        nativeBuildInputs = with pkgs; [
+          protoc-gen-go
+          makeWrapper
+        ];
+
+        # Build from cmd/elephant/elephant.go
+        subPackages = [
+          "cmd/elephant"
+        ];
+
+        postFixup = ''
+          wrapProgram $out/bin/elephant \
+              --prefix PATH : ${lib.makeBinPath (with pkgs; [fd])}
+        '';
+
+        meta = with lib; {
+          description = "Powerful data provider service and backend for building custom application launchers";
+          homepage = "https://github.com/abenz1267/elephant";
+          license = licenses.gpl3Only;
+          maintainers = [];
+          platforms = platforms.linux;
         };
-      });
+      };
 
-      packages = eachSystem (pkgs: {
-        default = self.packages.${pkgs.stdenv.system}.elephant-with-providers;
+      # Providers package - builds all providers with same Go toolchain
+      elephant-providers = pkgs.buildGo125Module rec {
+        pname = "elephant-providers";
+        version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
 
-        # Main elephant binary
-        elephant = pkgs.buildGo125Module {
-          pname = "elephant";
-          version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
+        src = ./.;
 
-          src = ./.;
+        vendorHash = "sha256-XYGh4ZXRly3MCPWse51eUMyjXqtHzKbPEyD0J8S/MDk=";
 
-          vendorHash = "sha256-XYGh4ZXRly3MCPWse51eUMyjXqtHzKbPEyD0J8S/MDk=";
+        buildInputs = with pkgs; [
+          wayland
+        ];
 
-          buildInputs = with pkgs; [
-            protobuf
-          ];
+        nativeBuildInputs = with pkgs; [
+          protobuf
+          protoc-gen-go
+        ];
 
-          nativeBuildInputs = with pkgs; [
-            protoc-gen-go
-            makeWrapper
-          ];
+        excludedProviders = [
+          "archlinuxpkgs"
+        ];
 
-          # Build from cmd/elephant/elephant.go
-          subPackages = [
-            "cmd/elephant"
-          ];
+        buildPhase = ''
+          runHook preBuild
 
-          postFixup = ''
-             wrapProgram $out/bin/elephant \
-            	    --prefix PATH : ${lib.makeBinPath (with pkgs; [ fd ])}
-          '';
+          echo "Building elephant providers..."
 
-          meta = with lib; {
-            description = "Powerful data provider service and backend for building custom application launchers";
-            homepage = "https://github.com/abenz1267/elephant";
-            license = licenses.gpl3Only;
-            maintainers = [ ];
-            platforms = platforms.linux;
-          };
-        };
+          EXCLUDE_LIST="${lib.concatStringsSep " " excludedProviders}"
 
-        # Providers package - builds all providers with same Go toolchain
-        elephant-providers = pkgs.buildGo125Module rec {
-          pname = "elephant-providers";
-          version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
-
-          src = ./.;
-
-          vendorHash = "sha256-XYGh4ZXRly3MCPWse51eUMyjXqtHzKbPEyD0J8S/MDk=";
-
-          buildInputs = with pkgs; [
-            wayland
-          ];
-
-          nativeBuildInputs = with pkgs; [
-            protobuf
-            protoc-gen-go
-          ];
-
-          excludedProviders = [
-            "archlinuxpkgs"
-          ];
-
-          buildPhase = ''
-            runHook preBuild
-
-            echo "Building elephant providers..."
-
-            EXCLUDE_LIST="${lib.concatStringsSep " " excludedProviders}"
-
-            is_excluded() {
-              target="$1"
-              for e in $EXCLUDE_LIST; do
-                [ -z "$e" ] && continue
-                if [ "$e" = "$target" ]; then
-                  return 0
-                fi
-              done
-              return 1
-            }
-
-            if [ -d ./internal/providers ]; then
-              for dir in ./internal/providers/*; do
-                [ -d "$dir" ] || continue
-                provider=$(basename "$dir")
-                if is_excluded "$provider"; then
-                  echo "Skipping excluded provider: $provider"
-                  continue
-                fi
-                set -- "$dir"/*.go
-                if [ -e "$1" ]; then
-                  echo "Building provider: $provider"
-                  if ! go build -buildmode=plugin -o "$provider.so" ./internal/providers/"$provider"; then
-                    echo "⚠ Failed to build provider: $provider"
-                    exit 1
-                  fi
-                  echo "Built $provider.so"
-                else
-                  echo "Skipping $provider: no .go files found"
-                fi
-              done
-            else
-              echo "No providers directory found at ./internal/providers"
-            fi
-
-            runHook postBuild
-          '';
-
-          installPhase = ''
-            runHook preInstall
-
-            mkdir -p $out/lib/elephant/providers
-
-            # Copy all built .so files
-            for so_file in *.so; do
-              if [[ -f "$so_file" ]]; then
-                cp "$so_file" "$out/lib/elephant/providers/"
-                echo "Installed provider: $so_file"
+          is_excluded() {
+            target="$1"
+            for e in $EXCLUDE_LIST; do
+              [ -z "$e" ] && continue
+              if [ "$e" = "$target" ]; then
+                return 0
               fi
             done
+            return 1
+          }
 
-            runHook postInstall
-          '';
+          if [ -d ./internal/providers ]; then
+            for dir in ./internal/providers/*; do
+              [ -d "$dir" ] || continue
+              provider=$(basename "$dir")
+              if is_excluded "$provider"; then
+                echo "Skipping excluded provider: $provider"
+                continue
+              fi
+              set -- "$dir"/*.go
+              if [ -e "$1" ]; then
+                echo "Building provider: $provider"
+                if ! go build -buildmode=plugin -o "$provider.so" ./internal/providers/"$provider"; then
+                  echo "⚠ Failed to build provider: $provider"
+                  exit 1
+                fi
+                echo "Built $provider.so"
+              else
+                echo "Skipping $provider: no .go files found"
+              fi
+            done
+          else
+            echo "No providers directory found at ./internal/providers"
+          fi
 
-          meta = with lib; {
-            description = "Elephant providers (Go plugins)";
-            homepage = "https://github.com/abenz1267/elephant";
-            license = licenses.gpl3Only;
-            platforms = platforms.linux;
-          };
+          runHook postBuild
+        '';
+
+        installPhase = ''
+          runHook preInstall
+
+          mkdir -p $out/lib/elephant/providers
+
+          # Copy all built .so files
+          for so_file in *.so; do
+            if [[ -f "$so_file" ]]; then
+              cp "$so_file" "$out/lib/elephant/providers/"
+              echo "Installed provider: $so_file"
+            fi
+          done
+
+          runHook postInstall
+        '';
+
+        meta = with lib; {
+          description = "Elephant providers (Go plugins)";
+          homepage = "https://github.com/abenz1267/elephant";
+          license = licenses.gpl3Only;
+          platforms = platforms.linux;
         };
+      };
 
-        # Combined package with elephant + providers
-        elephant-with-providers = pkgs.stdenv.mkDerivation {
-          pname = "elephant-with-providers";
-          version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
+      # Combined package with elephant + providers
+      elephant-with-providers = pkgs.stdenv.mkDerivation {
+        pname = "elephant-with-providers";
+        version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
 
-          dontUnpack = true;
+        dontUnpack = true;
 
-          buildInputs = [
-            self.packages.${pkgs.stdenv.system}.elephant
+        buildInputs = [
+          self.packages.${pkgs.stdenv.system}.elephant
+          self.packages.${pkgs.stdenv.system}.elephant-providers
+        ];
+
+        nativeBuildInputs = with pkgs; [
+          makeWrapper
+        ];
+
+        installPhase = ''
+          mkdir -p $out/bin $out/lib/elephant
+          cp ${self.packages.${pkgs.stdenv.system}.elephant}/bin/elephant $out/bin/
+          cp -r ${
             self.packages.${pkgs.stdenv.system}.elephant-providers
-          ];
+          }/lib/elephant/providers $out/lib/elephant/
+        '';
 
-          nativeBuildInputs = with pkgs; [
-            makeWrapper
-          ];
+        postFixup = ''
+          wrapProgram $out/bin/elephant \
+                --prefix PATH : ${
+            lib.makeBinPath (
+              with pkgs; [
+                wl-clipboard
+                libqalculate
+                imagemagick
+                bluez
+              ]
+            )
+          }
+        '';
 
-          installPhase = ''
-            mkdir -p $out/bin $out/lib/elephant
-            cp ${self.packages.${pkgs.stdenv.system}.elephant}/bin/elephant $out/bin/
-            cp -r ${
-              self.packages.${pkgs.stdenv.system}.elephant-providers
-            }/lib/elephant/providers $out/lib/elephant/
-          '';
-
-          postFixup = ''
-            wrapProgram $out/bin/elephant \
-                  --prefix PATH : ${
-                    lib.makeBinPath (
-                      with pkgs;
-                      [
-                        wl-clipboard
-                        libqalculate
-                        imagemagick
-                        bluez
-                      ]
-                    )
-                  }
-          '';
-
-          meta = with lib; {
-            description = "Elephant with all providers (complete installation)";
-            homepage = "https://github.com/abenz1267/elephant";
-            license = licenses.gpl3Only;
-            platforms = platforms.linux;
-          };
+        meta = with lib; {
+          description = "Elephant with all providers (complete installation)";
+          homepage = "https://github.com/abenz1267/elephant";
+          license = licenses.gpl3Only;
+          platforms = platforms.linux;
         };
-      });
-
-      homeManagerModules = {
-        default = self.homeManagerModules.elephant;
-        elephant = import ./nix/modules/home-manager.nix self;
       };
+    });
 
-      nixosModules = {
-        default = self.nixosModules.elephant;
-        elephant = import ./nix/modules/nixos.nix self;
-      };
+    homeManagerModules = {
+      default = self.homeManagerModules.elephant;
+      elephant = import ./nix/modules/home-manager.nix self;
     };
+
+    nixosModules = {
+      default = self.nixosModules.elephant;
+      elephant = import ./nix/modules/nixos.nix self;
+    };
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -8,221 +8,225 @@
     systems.url = "github:nix-systems/default-linux";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    systems,
-    ...
-  }: let
-    inherit (nixpkgs) lib;
-    eachSystem = f: lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
-  in {
-    formatter = eachSystem (pkgs: pkgs.alejandra);
+  outputs =
+    {
+      self,
+      nixpkgs,
+      systems,
+      ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+      eachSystem = f: lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      formatter = eachSystem (pkgs: pkgs.alejandra);
 
-    devShells = eachSystem (pkgs: {
-      default = pkgs.mkShell {
-        name = "elephant-dev-shell";
-        inputsFrom = [self.packages.${pkgs.stdenv.system}.elephant];
-        buildInputs = with pkgs; [
-          go
-          air
-          gcc
-          protobuf
-          protoc-gen-go
-          wl-clipboard
-          libqalculate
-          imagemagick
-          bluez
-        ];
-      };
-    });
-
-    packages = eachSystem (pkgs: {
-      default = self.packages.${pkgs.stdenv.system}.elephant-with-providers;
-
-      # Main elephant binary
-      elephant = pkgs.buildGo125Module {
-        pname = "elephant";
-        version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
-
-        src = ./.;
-
-        vendorHash = "sha256-XYGh4ZXRly3MCPWse51eUMyjXqtHzKbPEyD0J8S/MDk=";
-
-        buildInputs = with pkgs; [
-          protobuf
-        ];
-
-        nativeBuildInputs = with pkgs; [
-          protoc-gen-go
-          makeWrapper
-        ];
-
-        # Build from cmd/elephant/elephant.go
-        subPackages = [
-          "cmd/elephant"
-        ];
-
-        postFixup = ''
-          wrapProgram $out/bin/elephant \
-              --prefix PATH : ${lib.makeBinPath (with pkgs; [fd])}
-        '';
-
-        meta = with lib; {
-          description = "Powerful data provider service and backend for building custom application launchers";
-          homepage = "https://github.com/abenz1267/elephant";
-          license = licenses.gpl3Only;
-          maintainers = [];
-          platforms = platforms.linux;
+      devShells = eachSystem (pkgs: {
+        default = pkgs.mkShell {
+          name = "elephant-dev-shell";
+          inputsFrom = [ self.packages.${pkgs.stdenv.system}.elephant ];
+          buildInputs = with pkgs; [
+            go
+            gcc
+            protobuf
+            protoc-gen-go
+            air
+            wl-clipboard
+            libqalculate
+            imagemagick
+            bluez
+          ];
         };
-      };
+      });
 
-      # Providers package - builds all providers with same Go toolchain
-      elephant-providers = pkgs.buildGo125Module rec {
-        pname = "elephant-providers";
-        version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
+      packages = eachSystem (pkgs: {
+        default = self.packages.${pkgs.stdenv.system}.elephant-with-providers;
 
-        src = ./.;
+        # Main elephant binary
+        elephant = pkgs.buildGo125Module {
+          pname = "elephant";
+          version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
 
-        vendorHash = "sha256-XYGh4ZXRly3MCPWse51eUMyjXqtHzKbPEyD0J8S/MDk=";
+          src = ./.;
 
-        buildInputs = with pkgs; [
-          wayland
-        ];
+          vendorHash = "sha256-XYGh4ZXRly3MCPWse51eUMyjXqtHzKbPEyD0J8S/MDk=";
 
-        nativeBuildInputs = with pkgs; [
-          protobuf
-          protoc-gen-go
-        ];
+          buildInputs = with pkgs; [
+            protobuf
+          ];
 
-        excludedProviders = [
-          "archlinuxpkgs"
-        ];
+          nativeBuildInputs = with pkgs; [
+            protoc-gen-go
+            makeWrapper
+          ];
 
-        buildPhase = ''
-          runHook preBuild
+          # Build from cmd/elephant/elephant.go
+          subPackages = [
+            "cmd/elephant"
+          ];
 
-          echo "Building elephant providers..."
+          postFixup = ''
+             wrapProgram $out/bin/elephant \
+            	    --prefix PATH : ${lib.makeBinPath (with pkgs; [ fd ])}
+          '';
 
-          EXCLUDE_LIST="${lib.concatStringsSep " " excludedProviders}"
+          meta = with lib; {
+            description = "Powerful data provider service and backend for building custom application launchers";
+            homepage = "https://github.com/abenz1267/elephant";
+            license = licenses.gpl3Only;
+            maintainers = [ ];
+            platforms = platforms.linux;
+          };
+        };
 
-          is_excluded() {
-            target="$1"
-            for e in $EXCLUDE_LIST; do
-              [ -z "$e" ] && continue
-              if [ "$e" = "$target" ]; then
-                return 0
-              fi
-            done
-            return 1
-          }
+        # Providers package - builds all providers with same Go toolchain
+        elephant-providers = pkgs.buildGo125Module rec {
+          pname = "elephant-providers";
+          version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
 
-          if [ -d ./internal/providers ]; then
-            for dir in ./internal/providers/*; do
-              [ -d "$dir" ] || continue
-              provider=$(basename "$dir")
-              if is_excluded "$provider"; then
-                echo "Skipping excluded provider: $provider"
-                continue
-              fi
-              set -- "$dir"/*.go
-              if [ -e "$1" ]; then
-                echo "Building provider: $provider"
-                if ! go build -buildmode=plugin -o "$provider.so" ./internal/providers/"$provider"; then
-                  echo "⚠ Failed to build provider: $provider"
-                  exit 1
+          src = ./.;
+
+          vendorHash = "sha256-XYGh4ZXRly3MCPWse51eUMyjXqtHzKbPEyD0J8S/MDk=";
+
+          buildInputs = with pkgs; [
+            wayland
+          ];
+
+          nativeBuildInputs = with pkgs; [
+            protobuf
+            protoc-gen-go
+          ];
+
+          excludedProviders = [
+            "archlinuxpkgs"
+          ];
+
+          buildPhase = ''
+            runHook preBuild
+
+            echo "Building elephant providers..."
+
+            EXCLUDE_LIST="${lib.concatStringsSep " " excludedProviders}"
+
+            is_excluded() {
+              target="$1"
+              for e in $EXCLUDE_LIST; do
+                [ -z "$e" ] && continue
+                if [ "$e" = "$target" ]; then
+                  return 0
                 fi
-                echo "Built $provider.so"
-              else
-                echo "Skipping $provider: no .go files found"
+              done
+              return 1
+            }
+
+            if [ -d ./internal/providers ]; then
+              for dir in ./internal/providers/*; do
+                [ -d "$dir" ] || continue
+                provider=$(basename "$dir")
+                if is_excluded "$provider"; then
+                  echo "Skipping excluded provider: $provider"
+                  continue
+                fi
+                set -- "$dir"/*.go
+                if [ -e "$1" ]; then
+                  echo "Building provider: $provider"
+                  if ! go build -buildmode=plugin -o "$provider.so" ./internal/providers/"$provider"; then
+                    echo "⚠ Failed to build provider: $provider"
+                    exit 1
+                  fi
+                  echo "Built $provider.so"
+                else
+                  echo "Skipping $provider: no .go files found"
+                fi
+              done
+            else
+              echo "No providers directory found at ./internal/providers"
+            fi
+
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/lib/elephant/providers
+
+            # Copy all built .so files
+            for so_file in *.so; do
+              if [[ -f "$so_file" ]]; then
+                cp "$so_file" "$out/lib/elephant/providers/"
+                echo "Installed provider: $so_file"
               fi
             done
-          else
-            echo "No providers directory found at ./internal/providers"
-          fi
 
-          runHook postBuild
-        '';
+            runHook postInstall
+          '';
 
-        installPhase = ''
-          runHook preInstall
-
-          mkdir -p $out/lib/elephant/providers
-
-          # Copy all built .so files
-          for so_file in *.so; do
-            if [[ -f "$so_file" ]]; then
-              cp "$so_file" "$out/lib/elephant/providers/"
-              echo "Installed provider: $so_file"
-            fi
-          done
-
-          runHook postInstall
-        '';
-
-        meta = with lib; {
-          description = "Elephant providers (Go plugins)";
-          homepage = "https://github.com/abenz1267/elephant";
-          license = licenses.gpl3Only;
-          platforms = platforms.linux;
+          meta = with lib; {
+            description = "Elephant providers (Go plugins)";
+            homepage = "https://github.com/abenz1267/elephant";
+            license = licenses.gpl3Only;
+            platforms = platforms.linux;
+          };
         };
-      };
 
-      # Combined package with elephant + providers
-      elephant-with-providers = pkgs.stdenv.mkDerivation {
-        pname = "elephant-with-providers";
-        version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
+        # Combined package with elephant + providers
+        elephant-with-providers = pkgs.stdenv.mkDerivation {
+          pname = "elephant-with-providers";
+          version = lib.trim (builtins.readFile ./cmd/elephant/version.txt);
 
-        dontUnpack = true;
+          dontUnpack = true;
 
-        buildInputs = [
-          self.packages.${pkgs.stdenv.system}.elephant
-          self.packages.${pkgs.stdenv.system}.elephant-providers
-        ];
-
-        nativeBuildInputs = with pkgs; [
-          makeWrapper
-        ];
-
-        installPhase = ''
-          mkdir -p $out/bin $out/lib/elephant
-          cp ${self.packages.${pkgs.stdenv.system}.elephant}/bin/elephant $out/bin/
-          cp -r ${
+          buildInputs = [
+            self.packages.${pkgs.stdenv.system}.elephant
             self.packages.${pkgs.stdenv.system}.elephant-providers
-          }/lib/elephant/providers $out/lib/elephant/
-        '';
+          ];
 
-        postFixup = ''
-          wrapProgram $out/bin/elephant \
-                --prefix PATH : ${
-            lib.makeBinPath (
-              with pkgs; [
-                wl-clipboard
-                libqalculate
-                imagemagick
-                bluez
-              ]
-            )
-          }
-        '';
+          nativeBuildInputs = with pkgs; [
+            makeWrapper
+          ];
 
-        meta = with lib; {
-          description = "Elephant with all providers (complete installation)";
-          homepage = "https://github.com/abenz1267/elephant";
-          license = licenses.gpl3Only;
-          platforms = platforms.linux;
+          installPhase = ''
+            mkdir -p $out/bin $out/lib/elephant
+            cp ${self.packages.${pkgs.stdenv.system}.elephant}/bin/elephant $out/bin/
+            cp -r ${
+              self.packages.${pkgs.stdenv.system}.elephant-providers
+            }/lib/elephant/providers $out/lib/elephant/
+          '';
+
+          postFixup = ''
+            wrapProgram $out/bin/elephant \
+                  --prefix PATH : ${
+                    lib.makeBinPath (
+                      with pkgs;
+                      [
+                        wl-clipboard
+                        libqalculate
+                        imagemagick
+                        bluez
+                      ]
+                    )
+                  }
+          '';
+
+          meta = with lib; {
+            description = "Elephant with all providers (complete installation)";
+            homepage = "https://github.com/abenz1267/elephant";
+            license = licenses.gpl3Only;
+            platforms = platforms.linux;
+          };
         };
+      });
+
+      homeManagerModules = {
+        default = self.homeManagerModules.elephant;
+        elephant = import ./nix/modules/home-manager.nix self;
       };
-    });
 
-    homeManagerModules = {
-      default = self.homeManagerModules.elephant;
-      elephant = import ./nix/modules/home-manager.nix self;
+      nixosModules = {
+        default = self.nixosModules.elephant;
+        elephant = import ./nix/modules/nixos.nix self;
+      };
     };
-
-    nixosModules = {
-      default = self.nixosModules.elephant;
-      elephant = import ./nix/modules/nixos.nix self;
-    };
-  };
 }

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,9 @@ require (
 	github.com/pjbgf/sha1cd v0.5.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/yalue/native_endian v1.0.2 // indirect
 	golang.org/x/crypto v0.44.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,12 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tinylib/msgp v1.4.0 h1:SYOeDRiydzOw9kSiwdYp9UcBgPFtLU2WDHaJXyHruf8=
 github.com/tinylib/msgp v1.4.0/go.mod h1:cvjFkb4RiC8qSBOPMGPSzSAx47nAsfhLVTCZZNuHv5o=
 github.com/urfave/cli/v3 v3.4.1 h1:1M9UOCy5bLmGnuu1yn3t3CB4rG79Rtoxuv1sPhnm6qM=

--- a/internal/providers/load.go
+++ b/internal/providers/load.go
@@ -40,8 +40,11 @@ var (
 	QueryProviders map[uint32][]string
 	libDirs        = []string{
 		"/usr/lib/elephant",
+		"/usr/lib64/elephant",
 		"/usr/local/lib/elephant",
+		"/usr/local/lib64/elephant",
 		"/lib/elephant",
+		"/lib64/elephant",
 	}
 )
 

--- a/internal/providers/websearch/README.md
+++ b/internal/providers/websearch/README.md
@@ -17,7 +17,7 @@ Search the web with custom defined search engines.
 max_api_items = 10
 engine_finder_default_single = false
 
-# name is required must be unique
+# name and url are required 
 [[entries]]
 default = true
 name = "Example"

--- a/internal/providers/websearch/README.md
+++ b/internal/providers/websearch/README.md
@@ -8,35 +8,35 @@ Search the web with custom defined search engines.
 - Define custom search engines
 - Search with custom prefixes
 - Auto complete suggestions from any JSON API
+- Search multiple engines simultaneously with deduplicated suggestions
 - Engine finder to search configured engines
 
 ## Example Config
 
 ```toml
-text_prefix = ""
 max_api_items = 10
-engine_finder_default = false
+engine_finder_default_single = false
 
-# name and url are required
-# name must be unique
+# name is required must be unique
 [[entries]]
+default = true
 name = "Example"
 url = "https://www.example.com/search?q=%TERM%"
 
 [[entries]]
 default = true
+default_single = true
 name = "DuckDuckGo"
 icon = "duckduckgo"
-prefix = "!d"
+prefix = "@d"
 url = "https://duckduckgo.com/?q=%TERM%"
 suggestions_url = "https://ac.duckduckgo.com/ac/?q=%TERM%"
 suggestions_path = "#.phrase"
 
 [[entries]]
-default = false
 name = "Google"
 icon = "google"
-prefix = "!g"
+prefix = "@g"
 url = "https://www.google.com/search?q=%TERM%"
 suggestions_url = "https://suggestqueries.google.com/complete/search?client=firefox&q=%TERM%"
 suggestions_path = "1"
@@ -48,8 +48,10 @@ suggestions_path = "1"
 
 ```toml
 [[entries]]
+
+[[entries]]
 name = "Crunchyroll"
-prefix = "!anime"
+prefix = "@anime"
 url = "https://www.crunchyroll.com/search?q=%TERM%"
 # Suggestions from MyAnimeList for Crunchyroll search
 suggestions_url = "https://myanimelist.net/search/prefix.json?type=all&keyword=%TERM%&v=1"
@@ -62,13 +64,13 @@ suggestions_path = "categories.#(type==\"anime\").items.#.name"
 [[entries]]
 name = "Amazon"
 icon = "amazon"
-prefix = "!shop"
+prefix = "@shop"
 url = "https://www.amazon.ca/s?k=%TERM%"
 
 [[entries]]
 name = "Newegg"
-prefix = "!shop"
+prefix = "@shop"
 url = "https://www.newegg.ca/p/pl?d=%TERM%"
-suggestions_url = "https://www.newegg.ca/api/SearchKeyword?CountryCode=CAN&keyword=%TERM%&nodeId=-1&from=www.newegg.ca"
+suggestions_url = "https://www.newegg.ca/api/SearchKeyword?keyword=%TERM%"
 suggestions_path = "suggestion.keywords.#.keyword"
 ```

--- a/internal/providers/websearch/README.md
+++ b/internal/providers/websearch/README.md
@@ -63,7 +63,7 @@ suggestions_path = "categories.#(type==\"anime\").items.#.name"
 name = "Amazon"
 icon = "amazon"
 prefix = "!shop"
-url = "https://www.amazon.ca/s?k=%TERM%";
+url = "https://www.amazon.ca/s?k=%TERM%"
 
 [[entries]]
 name = "Newegg"

--- a/internal/providers/websearch/README.md
+++ b/internal/providers/websearch/README.md
@@ -1,12 +1,74 @@
-### Elephant Websearch
+# Elephant Websearch Provider
 
 Search the web with custom defined search engines.
 
-#### Example entry
+## Features
+
+- Opening URLs directly
+- Define custom search engines
+- Search with custom prefixes
+- Auto complete suggestions from any JSON API
+- Engine finder to search configured engines
+
+## Example Config
+
+```toml
+text_prefix = ""
+max_api_items = 10
+engine_finder_default = false
+
+# name and url are required
+# name must be unique
+[[entries]]
+name = "Example"
+url = "https://www.example.com/search?q=%TERM%"
+
+[[entries]]
+default = true
+name = "DuckDuckGo"
+icon = "duckduckgo"
+prefix = "!d"
+url = "https://duckduckgo.com/?q=%TERM%"
+suggestions_url = "https://ac.duckduckgo.com/ac/?q=%TERM%"
+suggestions_path = "#.phrase"
+
+[[entries]]
+default = false
+name = "Google"
+icon = "google"
+prefix = "!g"
+url = "https://www.google.com/search?q=%TERM%"
+suggestions_url = "https://suggestqueries.google.com/complete/search?client=firefox&q=%TERM%"
+suggestions_path = "1"
+```
+
+### Tips
+
+1.  The engine URL and suggestions API don't need to match
 
 ```toml
 [[entries]]
-default = true
-name = "Google"
-url = "https://www.google.com/search?q=%TERM%"
+name = "Crunchyroll"
+prefix = "!anime"
+url = "https://www.crunchyroll.com/search?q=%TERM%"
+# Suggestions from MyAnimeList for Crunchyroll search
+suggestions_url = "https://myanimelist.net/search/prefix.json?type=all&keyword=%TERM%&v=1"
+suggestions_path = "categories.#(type==\"anime\").items.#.name"
+```
+
+2. Give multiple engines the same prefix to query them simultaneously
+
+```toml
+[[entries]]
+name = "Amazon"
+icon = "amazon"
+prefix = "!shop"
+url = "https://www.amazon.ca/s?k=%TERM%";
+
+[[entries]]
+name = "Newegg"
+prefix = "!shop"
+url = "https://www.newegg.ca/p/pl?d=%TERM%"
+suggestions_url = "https://www.newegg.ca/api/SearchKeyword?CountryCode=CAN&keyword=%TERM%&nodeId=-1&from=www.newegg.ca"
+suggestions_path = "suggestion.keywords.#.keyword"
 ```

--- a/internal/providers/websearch/README.md
+++ b/internal/providers/websearch/README.md
@@ -1,8 +1,8 @@
-# Elephant Websearch Provider
+### Elephant Websearch Provider
 
 Search the web with custom defined search engines.
 
-## Features
+#### Features
 
 - Opening URLs directly
 - Define custom search engines
@@ -11,7 +11,7 @@ Search the web with custom defined search engines.
 - Search multiple engines simultaneously with deduplicated suggestions
 - Engine finder to search configured engines
 
-## Example Config
+#### Example Config
 
 ```toml
 max_api_items = 10
@@ -42,13 +42,11 @@ suggestions_url = "https://suggestqueries.google.com/complete/search?client=fire
 suggestions_path = "1"
 ```
 
-### Tips
+#### Tips
 
 1.  The engine URL and suggestions API don't need to match
 
 ```toml
-[[entries]]
-
 [[entries]]
 name = "Crunchyroll"
 prefix = "@anime"

--- a/internal/providers/websearch/activate.go
+++ b/internal/providers/websearch/activate.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"al.essio.dev/pkg/shellescape"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/common/history"
+)
+
+const (
+	ActionSearch           = "search"
+	ActionSearchSuggestion = "search_suggestion"
+	ActionOpenURL          = "open_url"
+)
+
+func Activate(single bool, identifier, action string, query string, args string, format uint8, conn net.Conn) {
+	switch action {
+	case ActionOpenURL:
+		address := query
+		if !strings.Contains(address, "://") {
+			address = fmt.Sprintf("https://%s", query)
+		}
+
+		openURL(address)
+
+	case ActionSearch:
+		engine := engineNameMap[identifier]
+
+		if args == "" {
+			args = query
+		}
+
+		_, args := splitEnginePrefix(args)
+
+		address := expandSubstitutions(engine.URL, args)
+		run(query, identifier, address)
+
+	case ActionSearchSuggestion:
+		currentSuggestionsMutex.RLock()
+		s, ok := currentSuggestions[identifier]
+		currentSuggestionsMutex.RUnlock()
+		if !ok {
+			slog.Error(Name, "activate", "missing suggestion", "id", identifier)
+			return
+		}
+
+		// TODO: Add engine history instead of suggestion history since suggestions are temporary
+		url := expandSubstitutions(s.Engine.URL, s.Content)
+		run(query, identifier, url)
+
+	case history.ActionDelete:
+		h.Remove(identifier)
+
+	default:
+		q := ""
+
+		if !config.EnginesAsActions {
+			slog.Error(Name, "activate", fmt.Sprintf("unknown action: %s", action))
+			return
+		}
+
+		for _, v := range config.Engines {
+			fmt.Println(action)
+			if v.Name == action {
+				q = v.URL
+				break
+			}
+		}
+
+		q = expandSubstitutions(q, args)
+		run(query, identifier, q)
+	}
+}
+
+func expandSubstitutions(format string, args string) string {
+	if strings.TrimSpace(args) == "" {
+		args = "\"\""
+	}
+
+	result := format
+	if strings.Contains(format, "%CLIPBOARD%") {
+		clipboardText := common.ClipboardText()
+		if clipboardText == "" {
+			slog.Error(Name, "activate", "empty clipboard")
+			args = "\"\""
+		}
+
+		result = strings.ReplaceAll(os.ExpandEnv(format), "%CLIPBOARD%", url.QueryEscape(clipboardText))
+	} else if strings.Contains(format, "%TERM%") {
+		result = strings.ReplaceAll(os.ExpandEnv(format), "%TERM%", url.QueryEscape(args))
+	}
+
+	return result
+}
+
+func run(query, identifier, url string) {
+	openURL(url)
+
+	if config.History {
+		h.Save(query, identifier)
+	}
+}
+
+func openURL(url string) {
+	cmdStr := fmt.Sprintf("%s %s %s", common.LaunchPrefix(""), config.Command, shellescape.Quote(url))
+	cmd := exec.Command("sh", "-c", strings.TrimSpace(cmdStr))
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	if err := cmd.Start(); err != nil {
+		slog.Error(Name, "executeCommand", err)
+		return
+	}
+
+	go cmd.Wait()
+}

--- a/internal/providers/websearch/activate.go
+++ b/internal/providers/websearch/activate.go
@@ -33,7 +33,7 @@ func Activate(single bool, identifier, action string, query string, args string,
 		openURL(address)
 
 	case ActionSearch:
-		engine := engineNameMap[identifier]
+		engine := engineIdentifierMap[identifier]
 
 		if args == "" {
 			args = query
@@ -54,7 +54,7 @@ func Activate(single bool, identifier, action string, query string, args string,
 		}
 
 		url := expandSubstitutions(s.Engine.URL, s.Content)
-		run(query, s.Engine.Name, url)
+		run(query, s.Engine.Identifier, url)
 
 	case history.ActionDelete:
 		h.Remove(identifier)
@@ -77,7 +77,7 @@ func Activate(single bool, identifier, action string, query string, args string,
 
 		q := engine.URL
 		q = expandSubstitutions(q, args)
-		run(query, engine.Name, q)
+		run(query, identifier, q)
 	}
 }
 

--- a/internal/providers/websearch/activate.go
+++ b/internal/providers/websearch/activate.go
@@ -22,7 +22,6 @@ const (
 )
 
 func Activate(single bool, identifier, action string, query string, args string, format uint8, conn net.Conn) {
-	fmt.Println("Test: ")
 	switch action {
 	case ActionOpenURL:
 		address := query

--- a/internal/providers/websearch/activate.go
+++ b/internal/providers/websearch/activate.go
@@ -22,6 +22,7 @@ const (
 )
 
 func Activate(single bool, identifier, action string, query string, args string, format uint8, conn net.Conn) {
+	fmt.Println("Test: ")
 	switch action {
 	case ActionOpenURL:
 		address := query
@@ -52,24 +53,31 @@ func Activate(single bool, identifier, action string, query string, args string,
 			return
 		}
 
-		// TODO: Add engine history instead of suggestion history since suggestions are temporary
 		url := expandSubstitutions(s.Engine.URL, s.Content)
-		run(query, identifier, url)
+		run(query, s.Engine.Name, url)
 
 	case history.ActionDelete:
 		h.Remove(identifier)
 
 	default:
-		q := ""
-
 		if !config.EnginesAsActions {
 			slog.Error(Name, "activate", fmt.Sprintf("unknown action: %s", action))
 			return
 		}
 
-		q = engineNameMap[action].URL
+		if args == "" {
+			args = query
+		}
+
+		engine := engineNameMap[action]
+		if engine == nil {
+			slog.Error(Name, "activate", "unknown engine", "action", action)
+			return
+		}
+
+		q := engine.URL
 		q = expandSubstitutions(q, args)
-		run(query, identifier, q)
+		run(query, engine.Name, q)
 	}
 }
 

--- a/internal/providers/websearch/activate.go
+++ b/internal/providers/websearch/activate.go
@@ -38,7 +38,7 @@ func Activate(single bool, identifier, action string, query string, args string,
 			args = query
 		}
 
-		_, args := splitEnginePrefix(args)
+		_, args = splitEnginePrefix(args)
 
 		address := expandSubstitutions(engine.URL, args)
 		run(query, identifier, address)
@@ -67,30 +67,18 @@ func Activate(single bool, identifier, action string, query string, args string,
 			return
 		}
 
-		for _, v := range config.Engines {
-			fmt.Println(action)
-			if v.Name == action {
-				q = v.URL
-				break
-			}
-		}
-
+		q = engineNameMap[action].URL
 		q = expandSubstitutions(q, args)
 		run(query, identifier, q)
 	}
 }
 
 func expandSubstitutions(format string, args string) string {
-	if strings.TrimSpace(args) == "" {
-		args = "\"\""
-	}
-
 	result := format
 	if strings.Contains(format, "%CLIPBOARD%") {
 		clipboardText := common.ClipboardText()
 		if clipboardText == "" {
 			slog.Error(Name, "activate", "empty clipboard")
-			args = "\"\""
 		}
 
 		result = strings.ReplaceAll(os.ExpandEnv(format), "%CLIPBOARD%", url.QueryEscape(clipboardText))

--- a/internal/providers/websearch/query.go
+++ b/internal/providers/websearch/query.go
@@ -40,12 +40,28 @@ func Query(conn net.Conn, query string, single bool, exact bool, _ uint8) []*pb.
 		entries = append(entries, addressEntry)
 	}
 
-	// TODO: re-add support for engines as actions
+	if config.EnginesAsActions {
+		actions := make([]string, len(config.Engines))
+		for i, engine := range config.Engines {
+			actions[i] = engine.Name
+		}
 
-	if query == "" && prefix == "" {
-		entries = append(entries, queryEmpty(single, exact)...)
+		actionEntry := &pb.QueryResponse_Item{
+			Identifier: "websearch",
+			Text:       fmt.Sprintf("%s%s", config.TextPrefix, query),
+			Actions:    actions,
+			Icon:       Icon(),
+			Provider:   Name,
+			Score:      1,
+			Type:       0,
+		}
+		entries = append(entries, actionEntry)
 	} else {
-		entries = append(entries, queryEngines(prefix, query, single, exact)...)
+		if query == "" && prefix == "" {
+			entries = append(entries, queryEmpty(single, exact)...)
+		} else {
+			entries = append(entries, queryEngines(prefix, query, single, exact)...)
+		}
 	}
 
 	// force search to be first when queried with prefix

--- a/internal/providers/websearch/query.go
+++ b/internal/providers/websearch/query.go
@@ -147,7 +147,7 @@ func queryEngines(prefix string, query string, single bool, exact bool) []*pb.Qu
 	// Engines finder
 	isPrefix := prefix == config.EngineFinderPrefix && prefix != ""
 	isDefault := prefix == "" && !single && config.EngineFinderDefault
-	isDefaultSingle := prefix == "" && single && config.EngineFinderDefault
+	isDefaultSingle := prefix == "" && single && config.EngineFinderDefaultSingle
 	if isPrefix || isDefault || isDefaultSingle {
 		entries = append(entries, listEngines(query, single, exact)...)
 	}

--- a/internal/providers/websearch/query.go
+++ b/internal/providers/websearch/query.go
@@ -1,0 +1,336 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/common/history"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
+	"github.com/tidwall/gjson"
+)
+
+func Query(conn net.Conn, query string, single bool, exact bool, _ uint8) []*pb.QueryResponse_Item {
+	entries := []*pb.QueryResponse_Item{}
+	prefix, query := splitEnginePrefix(query)
+
+	if likelyAddress(query) && prefix == "" {
+		address := query
+		if !strings.Contains(address, "://") {
+			address = fmt.Sprintf("https://%s", query)
+		}
+
+		addressEntry := &pb.QueryResponse_Item{
+			Identifier: "websearch",
+			Text:       fmt.Sprintf("visit: %s", address),
+			Actions:    []string{"open_url"},
+			Icon:       Icon(),
+			Provider:   Name,
+			Score:      1_000_000,
+		}
+		entries = append(entries, addressEntry)
+	}
+
+	// TODO: re-add support for engines as actions
+
+	if query == "" && prefix == "" {
+		entries = append(entries, queryEmpty(single, exact)...)
+	} else {
+		entries = append(entries, queryEngines(prefix, query, single, exact)...)
+	}
+
+	// force search to be first when queried with prefix
+	if prefix != "" {
+		for _, entry := range entries {
+			entry.Score += 10_000
+		}
+	}
+
+	return entries
+}
+
+func likelyAddress(query string) bool {
+	if !strings.Contains(query, ".") &&
+		!strings.Contains(query, "://") {
+		return false
+	}
+
+	if strings.Contains(query, " ") ||
+		strings.HasSuffix(query, ".") ||
+		strings.HasPrefix(query, ".") {
+		return false
+	}
+
+	if !strings.Contains(query, "://") {
+		query = fmt.Sprintf("https://%s", query)
+	}
+
+	_, err := url.Parse(query)
+
+	return err == nil
+}
+
+func queryEmpty(single bool, exact bool) []*pb.QueryResponse_Item {
+	entries := []*pb.QueryResponse_Item{}
+
+	entries = append(entries, listEngines("", single, exact)...)
+
+	// TODO Add configurable empty behavior
+	// TODO List Recent Browser History
+	// TODO List History Browser by frecency
+	// TODO List Bookmarks/Pins
+
+	return entries
+}
+
+func queryEngines(prefix string, query string, single bool, exact bool) []*pb.QueryResponse_Item {
+	entries := []*pb.QueryResponse_Item{}
+
+	queriedEngines := []Engine{}
+	if prefix == "" {
+		for _, engine := range config.Engines {
+			if (!single && engine.Default) || (single && engine.DefaultSingle) {
+				queriedEngines = append(queriedEngines, engine)
+			}
+		}
+	} else {
+		for _, engine := range config.Engines {
+			if engine.Prefix == prefix {
+				queriedEngines = append(queriedEngines, engine)
+			}
+		}
+	}
+
+	// Add direct search entry
+	for i, engine := range queriedEngines {
+		text := engine.Name
+		subtext := ""
+		if query != "" {
+			text = config.TextPrefix + query
+			subtext = engine.Name
+		}
+
+		// Force search above finder when single
+		score := int32(len(queriedEngines) - i)
+		if single && engine.DefaultSingle {
+			score += 1_000
+		}
+
+		entries = append(entries, &pb.QueryResponse_Item{
+			Identifier: engine.Name,
+			Text:       text,
+			Subtext:    subtext,
+			Actions:    []string{"search"},
+			Icon:       engine.Icon,
+			Provider:   Name,
+			Score:      score,
+			Type:       0,
+		})
+	}
+
+	// Add Suggestion Entries
+	if single || prefix != "" {
+		entries = append(entries, getAPISuggestions(queriedEngines, prefix, query, single)...)
+	}
+
+	// TODO: Add local browser history based suggestions
+
+	// Engines finder
+	isPrefix := prefix == config.EngineFinderPrefix && prefix != ""
+	isDefault := prefix == "" && !single && config.EngineFinderDefault
+	isDefaultSingle := prefix == "" && single && config.EngineFinderDefault
+	if isPrefix || isDefault || isDefaultSingle {
+		entries = append(entries, listEngines(query, single, exact)...)
+	}
+
+	return entries
+}
+
+func getAPISuggestions(queriedEngines []Engine, prefix string, query string, single bool) []*pb.QueryResponse_Item {
+	entries := []*pb.QueryResponse_Item{}
+
+	// Perform requests
+	allSuggestions := []Suggestion{}
+	var (
+		wg sync.WaitGroup
+		mu sync.Mutex
+	)
+
+	for engineIndex, engine := range queriedEngines {
+		if query == "" || engine.SuggestionsURL == "" {
+			continue
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			suggestions, err := fetchApiSuggestions(
+				engine.SuggestionsURL,
+				query,
+				engine.SuggestionsPath,
+			)
+			if err != nil {
+				slog.Warn("failed to fetch suggestions", "engine", engine.Name, "error", err)
+				return
+			}
+
+			local := make([]Suggestion, 0, len(suggestions))
+			for i, content := range suggestions {
+				identifier := engine.Name + ":" + content
+
+				local = append(local, Suggestion{
+					Identifier: identifier,
+					Content:    content,
+					Engine:     engine,
+					Score:      int32(-1000 - i - engineIndex),
+				})
+			}
+
+			mu.Lock()
+			allSuggestions = append(allSuggestions, local...)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	// Deduplicate and add entries
+	currentSuggestionsMutex.Lock()
+	currentSuggestions = make(map[string]Suggestion) // remove old suggestions
+
+	sort.Slice(allSuggestions, func(i, j int) bool {
+		return allSuggestions[i].Score > allSuggestions[j].Score
+	})
+	seenSuggestions := make(map[string]bool)
+	seenSuggestions[strings.ToLower(strings.TrimSpace(query))] = true
+	count := 0
+	for _, s := range allSuggestions {
+		if count >= config.MaxApiItems {
+			break
+		}
+
+		normalized := strings.ToLower(strings.TrimSpace(s.Content))
+		if !seenSuggestions[normalized] {
+			newEntry := &pb.QueryResponse_Item{
+				Identifier: s.Identifier,
+				Text:       s.Content,
+				Icon:       s.Engine.Icon,
+				Subtext:    s.Engine.Name,
+				Actions:    []string{"search_suggestion"},
+				Provider:   Name,
+				Score:      s.Score,
+				Type:       0,
+			}
+
+			entries = append(entries, newEntry)
+			currentSuggestions[s.Identifier] = s
+			seenSuggestions[normalized] = true
+			count += 1
+		}
+	}
+	currentSuggestionsMutex.Unlock()
+
+	return entries
+}
+
+func listEngines(query string, _ bool, exact bool) []*pb.QueryResponse_Item {
+	entries := []*pb.QueryResponse_Item{}
+
+	for k, v := range config.Engines {
+		text := v.Name
+		if v.Prefix != "" {
+			text = fmt.Sprintf("%s ( %s )", v.Name, v.Prefix)
+		}
+
+		e := &pb.QueryResponse_Item{
+			Identifier: v.Name,
+			Text:       text,
+			Subtext:    "",
+			Actions:    []string{"search"},
+			Icon:       v.Icon,
+			Provider:   Name,
+			Score:      int32(len(config.Engines) - k),
+			Type:       0,
+		}
+
+		if query != "" {
+			score, pos, start := common.FuzzyScore(query, v.Name, exact)
+
+			e.Score = score
+			e.Fuzzyinfo = &pb.QueryResponse_Item_FuzzyInfo{
+				Field:     "text",
+				Positions: pos,
+				Start:     start,
+			}
+		}
+
+		var usageScore int32
+		if config.History {
+			if e.Score > config.MinScore || query == "" && config.HistoryWhenEmpty {
+				usageScore = h.CalcUsageScore(query, e.Identifier)
+
+				if usageScore != 0 {
+					e.State = append(e.State, "history")
+					e.Actions = append(e.Actions, history.ActionDelete)
+				}
+
+				e.Score = e.Score + usageScore
+			}
+		}
+
+		if e.Score > config.MinScore || query == "" {
+			entries = append(entries, e)
+		}
+	}
+
+	return entries
+}
+
+func fetchApiSuggestions(address string, query string, jsonPath string) ([]string, error) {
+	request := expandSubstitutions(address, query)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(config.SuggestionsTimeout)*time.Millisecond)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", request, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	result := gjson.Get(string(body), jsonPath)
+
+	var suggestions []string
+	if result.IsArray() {
+		for _, item := range result.Array() {
+			suggestions = append(suggestions, item.String())
+		}
+	} else {
+		suggestions = append(suggestions, result.String())
+	}
+
+	return suggestions, nil
+}

--- a/internal/providers/websearch/query.go
+++ b/internal/providers/websearch/query.go
@@ -192,7 +192,7 @@ func getAPISuggestions(queriedEngines []Engine, prefix string, query string, sin
 					Identifier: identifier,
 					Content:    content,
 					Engine:     engine,
-					Score:      int32(-1000 - i - engineIndex),
+					Score:      int32(-i - engineIndex),
 				})
 			}
 

--- a/internal/providers/websearch/query.go
+++ b/internal/providers/websearch/query.go
@@ -306,6 +306,8 @@ func fetchApiSuggestions(address string, query string, jsonPath string) ([]strin
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0")
+
 	res, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %w", err)

--- a/internal/providers/websearch/query.go
+++ b/internal/providers/websearch/query.go
@@ -142,7 +142,7 @@ func queryEngines(prefix string, query string, single bool, exact bool) []*pb.Qu
 		}
 
 		entries = append(entries, &pb.QueryResponse_Item{
-			Identifier: engine.Name,
+			Identifier: engine.Identifier,
 			Text:       text,
 			Subtext:    subtext,
 			Actions:    []string{"search"},
@@ -202,7 +202,7 @@ func getAPISuggestions(queriedEngines []Engine, prefix string, query string, sin
 
 			local := make([]Suggestion, 0, len(suggestions))
 			for i, content := range suggestions {
-				identifier := engine.Name + ":" + content
+				identifier := hashSuggestionIdentifier(content, engine.Identifier)
 
 				local = append(local, Suggestion{
 					Identifier: identifier,
@@ -268,7 +268,7 @@ func listEngines(query string, _ bool, exact bool) []*pb.QueryResponse_Item {
 		}
 
 		e := &pb.QueryResponse_Item{
-			Identifier: v.Name,
+			Identifier: v.Identifier,
 			Text:       text,
 			Subtext:    "",
 			Actions:    []string{"search"},

--- a/internal/providers/websearch/setup.go
+++ b/internal/providers/websearch/setup.go
@@ -239,6 +239,8 @@ func Query(conn net.Conn, query string, single bool, exact bool, _ uint8) []*pb.
 		}
 	}
 
+	isURL := false
+
 	if strings.Contains(query, ".") && !strings.HasSuffix(query, ".") {
 		_, err := url.ParseRequestURI(fmt.Sprintf("https://%s", query))
 		if err == nil {
@@ -252,8 +254,11 @@ func Query(conn net.Conn, query string, single bool, exact bool, _ uint8) []*pb.
 			}
 
 			entries = append(entries, e)
+			isURL = true
 		}
-	} else {
+	}
+
+	if !isURL {
 		if config.EnginesAsActions {
 			a := []string{}
 

--- a/internal/providers/websearch/setup.go
+++ b/internal/providers/websearch/setup.go
@@ -111,6 +111,7 @@ func Setup() {
 
 	if len(config.Engines) == 1 {
 		config.Engines[0].Default = true
+		config.Engines[0].DefaultSingle = true
 	}
 
 	for k, v := range config.Engines {
@@ -125,7 +126,6 @@ func Setup() {
 		}
 
 		if v.Prefix != "" {
-			engineNameMap[v.Prefix] = &config.Engines[k]
 			handlers.WebsearchPrefixes[v.Prefix] = v.Name
 		}
 
@@ -139,7 +139,7 @@ func splitEnginePrefix(query string) (string, string) {
 	prefix := ""
 	found := false
 	for _, engine := range config.Engines {
-		if strings.HasPrefix(query, engine.Prefix) {
+		if engine.Prefix != "" && strings.HasPrefix(query, engine.Prefix) {
 			prefix = engine.Prefix
 			query = strings.TrimPrefix(query, prefix)
 			found = true

--- a/internal/providers/websearch/setup.go
+++ b/internal/providers/websearch/setup.go
@@ -44,7 +44,7 @@ type Config struct {
 	AlwaysShowDefault         bool     `koanf:"always_show_default" desc:"show default search engine when multiple providers are queried" default:"true"`
 	EngineFinderPrefix        string   `koanf:"engine_finder_prefix" desc:"prefix for explicitly querying the engine finder" default:"!e"`
 	EngineFinderDefault       bool     `koanf:"engine_finder_default" desc:"include engine finder results when searching with no engine prefix" default:"false"`
-	EngineFinderDefaultSingle bool     `koanf:"engine_finder_default" desc:"display by default when no engine prefix" default:"true"`
+	EngineFinderDefaultSingle bool     `koanf:"engine_finder_default_single" desc:"display by default when no engine prefix" default:"true"`
 	TextPrefix                string   `koanf:"text_prefix" desc:"text prefix for search entries" default:"Search: "`
 	Command                   string   `koanf:"command" desc:"default command to be executed. supports %VALUE%." default:"xdg-open"`
 	MaxApiItems               int      `koanf:"max_api_items" desc:"maximum final number of api suggestion items" default:"4"`

--- a/internal/providers/websearch/setup.go
+++ b/internal/providers/websearch/setup.go
@@ -41,8 +41,8 @@ type Config struct {
 	History                   bool     `koanf:"history" desc:"consider usage history for engine sorting" default:"true"`
 	HistoryWhenEmpty          bool     `koanf:"history_when_empty" desc:"consider usage history when query is empty" default:"false"`
 	EnginesAsActions          bool     `koanf:"engines_as_actions" desc:"run engines as actions" default:"true"`
-	AlwaysShowDefault         bool     `koanf:"always_show_default" desc:"show default search engine when multiple providers are queried" default:"true"`
-	EngineFinderPrefix        string   `koanf:"engine_finder_prefix" desc:"prefix for explicitly querying the engine finder" default:"!e"`
+	AlwaysShowDefault         bool     `koanf:"always_show_default" desc:"show default search engine when multiple providers are queried" default:"false"`
+	EngineFinderPrefix        string   `koanf:"engine_finder_prefix" desc:"prefix for explicitly querying the engine finder" default:"@e"`
 	EngineFinderDefault       bool     `koanf:"engine_finder_default" desc:"include engine finder results when searching with no engine prefix" default:"false"`
 	EngineFinderDefaultSingle bool     `koanf:"engine_finder_default_single" desc:"display by default when no engine prefix" default:"true"`
 	TextPrefix                string   `koanf:"text_prefix" desc:"text prefix for search entries" default:"Search: "`
@@ -77,7 +77,7 @@ func Setup() {
 		History:                   true,
 		HistoryWhenEmpty:          false,
 		EnginesAsActions:          false,
-		EngineFinderPrefix:        "!e",
+		EngineFinderPrefix:        "@e",
 		EngineFinderDefault:       false,
 		EngineFinderDefaultSingle: true,
 		TextPrefix:                "Search: ",

--- a/internal/providers/websearch/setup.go
+++ b/internal/providers/websearch/setup.go
@@ -100,17 +100,16 @@ func Setup() {
 	handlers.WebsearchAlwaysShow = config.AlwaysShowDefault
 
 	if len(config.Engines) == 0 {
-		config.Engines =
-			append(config.Engines,
-				Engine{
-					Name:    "Google",
-					Default: true,
-					URL:     "https://www.google.com/search?q=%TERM%",
-					// TODO: Enable suggestion by default after async additions have been added
-					//// SuggestionsURL:  "https://suggestqueries.google.com/complete/search?client=firefox&q=%TERM%",
-					//// SuggestionsPath: "1",
-				},
-			)
+		config.Engines = append(config.Engines,
+			Engine{
+				Name:    "Google",
+				Default: true,
+				URL:     "https://www.google.com/search?q=%TERM%",
+				// TODO: Enable suggestion by default after async additions have been added
+				//// SuggestionsURL:  "https://suggestqueries.google.com/complete/search?client=firefox&q=%TERM%",
+				//// SuggestionsPath: "1",
+			},
+		)
 	}
 
 	if len(config.Engines) == 1 {
@@ -152,25 +151,17 @@ func hashSuggestionIdentifier(content, engineIdentifier string) string {
 }
 
 func splitEnginePrefix(query string) (string, string) {
-	prefix := ""
-	found := false
 	for _, engine := range config.Engines {
-		if engine.Prefix != "" && strings.HasPrefix(query, engine.Prefix) {
-			prefix = engine.Prefix
-			query = strings.TrimPrefix(query, prefix)
-			found = true
-			break
+		if after, found := strings.CutPrefix(query, engine.Prefix); engine.Prefix != "" && found {
+			return engine.Prefix, strings.TrimSpace(after)
 		}
 	}
 
-	if !found && strings.HasPrefix(query, config.EngineFinderPrefix) {
-		prefix = config.EngineFinderPrefix
-		query = strings.TrimPrefix(query, config.EngineFinderPrefix)
+	if after, found := strings.CutPrefix(query, config.EngineFinderPrefix); config.EngineFinderPrefix != "" && found {
+		return config.EngineFinderPrefix, strings.TrimSpace(after)
 	}
 
-	query = strings.TrimSpace(query)
-
-	return prefix, query
+	return "", query
 }
 
 func Available() bool {

--- a/internal/providers/websearch/setup.go
+++ b/internal/providers/websearch/setup.go
@@ -3,17 +3,11 @@ package main
 import (
 	_ "embed"
 	"fmt"
-	"log/slog"
-	"net"
-	"net/url"
-	"os"
-	"os/exec"
-	"slices"
-	"strconv"
+	"net/http"
 	"strings"
-	"syscall"
+	"sync"
+	"time"
 
-	"al.essio.dev/pkg/shellescape"
 	"github.com/abenz1267/elephant/v2/internal/comm/handlers"
 	"github.com/abenz1267/elephant/v2/internal/util"
 	"github.com/abenz1267/elephant/v2/pkg/common"
@@ -22,33 +16,56 @@ import (
 )
 
 var (
-	Name       = "websearch"
-	NamePretty = "Websearch"
-	config     *Config
-	prefixes   = make(map[string]int)
-	h          = history.Load(Name)
+	Name                    = "websearch"
+	NamePretty              = "Web Search"
+	config                  *Config
+	h                       = history.Load(Name)
+	currentSuggestions      = make(map[string]Suggestion)
+	currentSuggestionsMutex = &sync.RWMutex{}
+	engineNameMap           = make(map[string]*Engine)
+	httpClient              = &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns:        10,
+			MaxIdleConnsPerHost: 5,
+			IdleConnTimeout:     30 * time.Second,
+		},
+	}
 )
 
 //go:embed README.md
 var readme string
 
 type Config struct {
-	common.Config     `koanf:",squash"`
-	Engines           []Engine `koanf:"entries" desc:"entries" default:"google"`
-	History           bool     `koanf:"history" desc:"make use of history for sorting" default:"true"`
-	HistoryWhenEmpty  bool     `koanf:"history_when_empty" desc:"consider history when query is empty" default:"false"`
-	EnginesAsActions  bool     `koanf:"engines_as_actions" desc:"run engines as actions" default:"true"`
-	AlwaysShowDefault bool     `koanf:"always_show_default" desc:"always show the default search engine when queried" default:"true"`
-	TextPrefix        string   `koanf:"text_prefix" desc:"prefix for the entry text" default:"Search: "`
-	Command           string   `koanf:"command" desc:"default command to be executed. supports %VALUE%." default:"xdg-open"`
+	common.Config             `koanf:",squash"`
+	Engines                   []Engine `koanf:"entries" desc:"entries" default:"google"`
+	History                   bool     `koanf:"history" desc:"consider usage history for engine sorting" default:"true"`
+	HistoryWhenEmpty          bool     `koanf:"history_when_empty" desc:"consider usage history when query is empty" default:"false"`
+	EnginesAsActions          bool     `koanf:"engines_as_actions" desc:"run engines as actions" default:"true"`
+	AlwaysShowDefault         bool     `koanf:"always_show_default" desc:"show default search engine when multiple providers are queried" default:"true"`
+	EngineFinderPrefix        string   `koanf:"engine_finder_prefix" desc:"prefix for explicitly querying the engine finder" default:"!e"`
+	EngineFinderDefault       bool     `koanf:"engine_finder_default" desc:"include engine finder results when searching with no engine prefix" default:"false"`
+	EngineFinderDefaultSingle bool     `koanf:"engine_finder_default" desc:"display by default when no engine prefix" default:"true"`
+	TextPrefix                string   `koanf:"text_prefix" desc:"text prefix for search entries" default:"Search: "`
+	Command                   string   `koanf:"command" desc:"default command to be executed. supports %VALUE%." default:"xdg-open"`
+	MaxApiItems               int      `koanf:"max_api_items" desc:"maximum final number of api suggestion items" default:"4"`
+	SuggestionsTimeout        int      `koanf:"suggestions_timeout" desc:"timeout at which a suggestion query will be dropped" default:"1000"`
 }
 
 type Engine struct {
-	Name    string `koanf:"name" desc:"name of the entry" default:""`
-	Default bool   `koanf:"default" desc:"entry to display when querying multiple providers" default:""`
-	Prefix  string `koanf:"prefix" desc:"prefix to actively trigger this entry" default:""`
-	URL     string `koanf:"url" desc:"url, example: 'https://www.google.com/search?q=%TERM%'" default:""`
-	Icon    string `koanf:"icon" desc:"icon to display, fallsback to global" default:""`
+	Name            string `koanf:"name" desc:"name of the entry" default:""`
+	Default         bool   `koanf:"default" desc:"display by default when querying multiple providers" default:"false"`
+	DefaultSingle   bool   `koanf:"default_single" desc:"display by default when querying only the websearch provider" default:"false"`
+	Prefix          string `koanf:"prefix" desc:"prefix to actively trigger this entry" default:""`
+	URL             string `koanf:"url" desc:"url, example: 'https://www.google.com/search?q=%TERM%'" default:""`
+	Icon            string `koanf:"icon" desc:"icon to display, fallsback to global" default:""`
+	SuggestionsURL  string `koanf:"suggestions_url" desc:"API endpoint for suggestions" default:""`
+	SuggestionsPath string `koanf:"suggestions_path" desc:"JSON path to extract suggestions" default:"1"`
+}
+type Suggestion struct {
+	Identifier string
+	Content    string
+	Engine     Engine
+	Score      int32
 }
 
 func Setup() {
@@ -57,12 +74,17 @@ func Setup() {
 			Icon:     "applications-internet",
 			MinScore: 20,
 		},
-		History:           true,
-		HistoryWhenEmpty:  false,
-		EnginesAsActions:  false,
-		TextPrefix:        "Search: ",
-		Command:           "xdg-open",
-		AlwaysShowDefault: true,
+		History:                   true,
+		HistoryWhenEmpty:          false,
+		EnginesAsActions:          false,
+		EngineFinderPrefix:        "!e",
+		EngineFinderDefault:       false,
+		EngineFinderDefaultSingle: true,
+		TextPrefix:                "Search: ",
+		Command:                   "xdg-open",
+		AlwaysShowDefault:         true,
+		MaxApiItems:               4,
+		SuggestionsTimeout:        1000,
 	}
 
 	common.LoadConfig(Name, config)
@@ -71,42 +93,68 @@ func Setup() {
 		NamePretty = config.NamePretty
 	}
 
+	handlers.WebsearchAlwaysShow = config.AlwaysShowDefault
+
 	if len(config.Engines) == 0 {
-		config.Engines = append(config.Engines, Engine{
-			Name:    "Google",
-			Default: true,
-			URL:     "https://www.google.com/search?q=%TERM%",
-		})
+		config.Engines =
+			append(config.Engines,
+				Engine{
+					Name:    "Google",
+					Default: true,
+					URL:     "https://www.google.com/search?q=%TERM%",
+					// TODO: Enable suggestion by default after async additions have been added
+					//// SuggestionsURL:  "https://suggestqueries.google.com/complete/search?client=firefox&q=%TERM%",
+					//// SuggestionsPath: "1",
+				},
+			)
 	}
 
 	if len(config.Engines) == 1 {
 		config.Engines[0].Default = true
 	}
 
-	handlers.WebsearchAlwaysShow = config.AlwaysShowDefault
-
 	for k, v := range config.Engines {
-		if v.Default {
-			handlers.MaxGlobalItemsToDisplayWebsearch++
+		engineNameMap[v.Name] = &config.Engines[k]
+
+		if v.Icon == "" {
+			config.Engines[k].Icon = config.Config.Icon
+		}
+
+		if v.SuggestionsPath == "" {
+			config.Engines[k].SuggestionsPath = "1" // Assume open search format by default
 		}
 
 		if v.Prefix != "" {
-			prefixes[v.Prefix] = k
+			engineNameMap[v.Prefix] = &config.Engines[k]
 			handlers.WebsearchPrefixes[v.Prefix] = v.Name
+		}
+
+		if v.Default {
+			handlers.MaxGlobalItemsToDisplayWebsearch++
+		}
+	}
+}
+
+func splitEnginePrefix(query string) (string, string) {
+	prefix := ""
+	found := false
+	for _, engine := range config.Engines {
+		if strings.HasPrefix(query, engine.Prefix) {
+			prefix = engine.Prefix
+			query = strings.TrimPrefix(query, prefix)
+			found = true
+			break
 		}
 	}
 
-	slices.SortFunc(config.Engines, func(a, b Engine) int {
-		if a.Default {
-			return -1
-		}
+	if !found && strings.HasPrefix(query, config.EngineFinderPrefix) {
+		prefix = config.EngineFinderPrefix
+		query = strings.TrimPrefix(query, config.EngineFinderPrefix)
+	}
 
-		if b.Default {
-			return 1
-		}
+	query = strings.TrimSpace(query)
 
-		return 0
-	})
+	return prefix, query
 }
 
 func Available() bool {
@@ -117,259 +165,6 @@ func PrintDoc() {
 	fmt.Println(readme)
 	fmt.Println()
 	util.PrintConfig(Config{}, Name)
-}
-
-const (
-	ActionSearch  = "search"
-	ActionOpenURL = "open_url"
-)
-
-func Activate(single bool, identifier, action string, query string, args string, format uint8, conn net.Conn) {
-	switch action {
-	case ActionOpenURL:
-		address := query
-		if !strings.Contains(address, "://") {
-			address = fmt.Sprintf("https://%s", query)
-		}
-
-		cmd := exec.Command("sh", "-c", strings.TrimSpace(fmt.Sprintf("%s xdg-open %s", common.LaunchPrefix(""), shellescape.Quote(address))))
-
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Setsid: true,
-		}
-
-		err := cmd.Start()
-		if err != nil {
-			slog.Error(Name, "activate", err)
-		} else {
-			go func() {
-				cmd.Wait()
-			}()
-		}
-	case history.ActionDelete:
-		h.Remove(identifier)
-		return
-	case ActionSearch:
-		i, _ := strconv.Atoi(identifier)
-
-		for k := range prefixes {
-			if after, ok := strings.CutPrefix(query, k); ok {
-				query = after
-				break
-			}
-		}
-
-		if args == "" {
-			args = query
-		}
-
-		q := ""
-
-		if strings.Contains(config.Engines[i].URL, "%CLIPBOARD%") {
-			clipboard := common.ClipboardText()
-
-			if clipboard == "" {
-				slog.Error(Name, "activate", "empty clipbpoard")
-				return
-			}
-
-			q = strings.ReplaceAll(os.ExpandEnv(config.Engines[i].URL), "%CLIPBOARD%", url.QueryEscape(clipboard))
-		} else {
-			q = strings.ReplaceAll(os.ExpandEnv(config.Engines[i].URL), "%TERM%", url.QueryEscape(strings.TrimSpace(args)))
-		}
-
-		run(query, identifier, q)
-	default:
-		q := ""
-
-		if !config.EnginesAsActions {
-			slog.Error(Name, "activate", fmt.Sprintf("unknown action: %s", action))
-			return
-		}
-
-		for _, v := range config.Engines {
-			if v.Name == action {
-				q = v.URL
-				break
-			}
-		}
-
-		if strings.Contains(q, "%CLIPBOARD%") {
-			clipboard := common.ClipboardText()
-
-			if clipboard == "" {
-				slog.Error(Name, "activate", "empty clipbpoard")
-				return
-			}
-
-			q = strings.ReplaceAll(q, "%CLIPBOARD%", url.QueryEscape(clipboard))
-		} else {
-			q = strings.ReplaceAll(q, "%TERM%", url.QueryEscape(strings.TrimSpace(query)))
-		}
-
-		run(query, identifier, q)
-	}
-}
-
-func run(query, identifier, q string) {
-	cmd := exec.Command("sh", "-c", strings.TrimSpace(fmt.Sprintf("%s %s %s", common.LaunchPrefix(""), config.Command, shellescape.Quote(q))))
-
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setsid: true,
-	}
-
-	err := cmd.Start()
-	if err != nil {
-		slog.Error(Name, "activate", err)
-	} else {
-		go func() {
-			cmd.Wait()
-		}()
-	}
-
-	if config.History {
-		h.Save(query, identifier)
-	}
-}
-
-func isAddress(query string) bool {
-	if !(strings.Contains(query, ".") ||
-		strings.Contains(query, "://")) ||
-		strings.Contains(query, " ") ||
-		strings.HasSuffix(query, ".") ||
-		strings.HasPrefix(query, ".") {
-		return false
-	}
-
-	return true
-}
-
-func Query(conn net.Conn, query string, single bool, exact bool, _ uint8) []*pb.QueryResponse_Item {
-	entries := []*pb.QueryResponse_Item{}
-
-	// Get current engine prefix if it exists
-	prefix := ""
-	for enginePrefix := range prefixes {
-		if strings.HasPrefix(query, enginePrefix) {
-			prefix = enginePrefix
-			break
-		}
-	}
-
-	// When an address entered directly add visit entry
-	if isAddress(query) && prefix == "" {
-		address := query
-		if !strings.Contains(address, "://") {
-			address = fmt.Sprintf("https://%s", query)
-		}
-
-		addressEntry := &pb.QueryResponse_Item{
-			Identifier: "websearch",
-			Text:       fmt.Sprintf("visit: %s", address),
-			Actions:    []string{"open_url"},
-			Icon:       Icon(),
-			Provider:   Name,
-			Score:      1000000,
-		}
-
-		entries = append(entries, addressEntry)
-		}
-	} else {
-		if config.EnginesAsActions {
-			a := []string{}
-
-			for _, v := range config.Engines {
-				a = append(a, v.Name)
-			}
-
-			e := &pb.QueryResponse_Item{
-				Identifier: "websearch",
-				Text:       fmt.Sprintf("%s%s", config.TextPrefix, query),
-				Actions:    a,
-				Icon:       Icon(),
-				Provider:   Name,
-				Score:      1,
-				Type:       0,
-			}
-
-			entries = append(entries, e)
-		} else {
-			if single {
-				for k, v := range config.Engines {
-					icon := v.Icon
-					if icon == "" {
-						icon = config.Icon
-					}
-
-					e := &pb.QueryResponse_Item{
-						Identifier: strconv.Itoa(k),
-						Text:       v.Name,
-						Subtext:    "",
-						Actions:    []string{"search"},
-						Icon:       icon,
-						Provider:   Name,
-						Score:      int32(100 - k),
-						Type:       0,
-					}
-
-					if query != "" {
-						score, pos, start := common.FuzzyScore(query, v.Name, exact)
-
-						e.Score = score
-						e.Fuzzyinfo = &pb.QueryResponse_Item_FuzzyInfo{
-							Field:     "text",
-							Positions: pos,
-							Start:     start,
-						}
-					}
-
-					var usageScore int32
-					if config.History {
-						if e.Score > config.MinScore || query == "" && config.HistoryWhenEmpty {
-							usageScore = h.CalcUsageScore(query, e.Identifier)
-
-							if usageScore != 0 {
-								e.State = append(e.State, "history")
-								e.Actions = append(e.Actions, history.ActionDelete)
-							}
-
-							e.Score = e.Score + usageScore
-						}
-					}
-
-					if e.Score > config.MinScore || query == "" {
-						entries = append(entries, e)
-					}
-				}
-			}
-
-			if len(entries) == 0 || !single {
-				for k, v := range config.Engines {
-					if v.Default || (prefix != "" && v.Prefix == prefix) {
-						icon := v.Icon
-						if icon == "" {
-							icon = config.Icon
-						}
-
-						e := &pb.QueryResponse_Item{
-							Identifier: strconv.Itoa(k),
-							Text:       v.Name,
-							Subtext:    "",
-							Actions:    []string{"search"},
-							Icon:       icon,
-							Provider:   Name,
-							Score:      int32(15 - k),
-							Type:       0,
-						}
-
-						entries = append(entries, e)
-					}
-				}
-			}
-		}
-	}
-
-	return entries
 }
 
 func Icon() string {


### PR DESCRIPTION
This primarily adds the ability to get suggestions for queried engine while in single mode or when using an engine prefix. Behavior `should` remain mostly the same when using an old / default config to see changes you will need to configure the new options (see provider readme).

## Changes
- Add previously missing development dependencies for nix devshell
- Add direnv to auto start nix devshell
- Add ability to configure engines with any custom suggestions api using `suggestions_url` and `suggestion_path`
- Allow url protocols other than https
- Allow querying "Search: " results for `default_single` engines when searching in single mode
- Display suggestions for queried engines while in single mode or when using engine prefix
- Add various config options for `engine_finder_*` which can be used to disable the ability to search for/find engines when in single mode
- Show engine prefix in UI similar to providerlist
- Show query text instead instead of engine name when querying an engine
- Refactor

## TODO
- Find some way to asynchronously stream / request new items on client mitigating slow api results

## Also
Unrelated but the update-nix-hash action is failing because it needs "Read and write permissions" to create a PRs. The option should be [here](https://github.com/abenz1267/elephant/settings/actions) in the repo settings 