### PR TITLE
Change MatchType to int in Bitwarden provider

### DIFF
--- a/internal/providers/bitwarden/activate.go
+++ b/internal/providers/bitwarden/activate.go
@@ -39,7 +39,7 @@ type RbwLoginData struct {
 
 type RbwUris struct {
 	Uri       string `json:"uri"`
-	MatchType string `json:"match_type"`
+	MatchType int    `json:"match_type"`
 }
 
 func syncLocalRbwVault() {


### PR DESCRIPTION
The MatchType in the rbw json seems to be an int not a string so this should fix errors like:

ERROR bitwarden parse="json: cannot unmarshal number into Go struct field RbwUris.data.uris.match_type of type string"