### PR TITLE
feat(providers): add new wireplumber audio control plugin

### DIFF
--- a/internal/providers/wireplumber/README.md
+++ b/internal/providers/wireplumber/README.md
@@ -1,0 +1,8 @@
+### Wireplumber
+
+Configure audio devices via Pipewire/Wireplumber.
+
+#### Requirements
+
+- `pipewire`
+- `wireplumber`

--- a/internal/providers/wireplumber/makefile
+++ b/internal/providers/wireplumber/makefile
@@ -1,0 +1,39 @@
+DESTDIR ?=
+CONFIGDIR = $(DESTDIR)/etc/xdg/elephant/providers
+
+GO_BUILD_FLAGS = -buildvcs=false -buildmode=plugin -trimpath
+PLUGIN_NAME = wireplumber.so
+
+.PHONY: all build install uninstall clean
+
+all: build
+
+build:
+	go build $(GO_BUILD_FLAGS)
+
+install: build
+	# Install plugin
+	install -Dm 755 $(PLUGIN_NAME) $(CONFIGDIR)/$(PLUGIN_NAME)
+
+uninstall:
+	rm -f $(CONFIGDIR)/$(PLUGIN_NAME)
+
+clean:
+	go clean
+	rm -f $(PLUGIN_NAME)
+
+dev-install: install
+
+help:
+	@echo "Available targets:"
+	@echo "  all       - Build the plugin (default)"
+	@echo "  build     - Build the plugin"
+	@echo "  install   - Install the plugin"
+	@echo "  uninstall - Remove installed plugin"
+	@echo "  clean     - Clean build artifacts"
+	@echo "  help      - Show this help"
+	@echo ""
+	@echo "Variables:"
+	@echo "  DESTDIR   - Destination directory for staged installs"
+	@echo ""
+	@echo "Note: This builds a Go plugin (.so file) for elephant"

--- a/internal/providers/wireplumber/pipewire.go
+++ b/internal/providers/wireplumber/pipewire.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type PipewireDumpNode []struct {
+	ID      int    `json:"id"`
+	Type    string `json:"type"`
+	Version int    `json:"version"`
+	Info    struct {
+		Props struct {
+			NodeName        string `json:"node.name"`
+			NodeDescription string `json:"node.description"`
+			MediaClass      string `json:"media.class"`
+		} `json:"props"`
+	} `json:"info"`
+}
+
+type PipewireDumpMetadata []struct {
+	ID      int    `json:"id"`
+	Type    string `json:"type"`
+	Version int    `json:"version"`
+	Props   struct {
+		MetadataName string `json:"metadata.name"`
+		ObjectSerial int    `json:"object.serial"`
+	} `json:"props"`
+	Metadata []struct {
+		Subject int    `json:"subject"`
+		Key     string `json:"key"`
+		Type    string `json:"type"`
+		Value   struct {
+			Name string `json:"name"`
+		} `json:"value"`
+	} `json:"metadata"`
+}
+
+const (
+	WpCtlCommand  = "wpctl"
+	PwDumpCommand = "pw-dump"
+)
+
+const (
+	PipewireTypeSource = "Audio/Source"
+	PipewireTypeSink   = "Audio/Sink"
+)
+
+type PipewireDevice struct {
+	ID           int
+	Description  string
+	Selected     bool
+	Volume       int
+	Muted        bool
+	PipewireType string
+}
+
+func runCommand(cmd *exec.Cmd) error {
+	err := cmd.Start()
+
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		cmd.Wait()
+	}()
+
+	return nil
+}
+
+func getVolumeState(deviceId int) (int, bool, error) {
+	cmd := exec.Command(WpCtlCommand, "get-volume", strconv.Itoa(deviceId))
+	output, err := cmd.Output()
+	if err != nil {
+		return 0, false, err
+	}
+
+	// e.g. "Volume: 40.0 [MUTED]"
+	outputString := string(output)
+	muted := strings.Contains(outputString, "MUTED")
+
+	// extract volume from output string (i.e. see example output above)
+	_, volStr, _ := strings.Cut(outputString, ": ")
+	volStr, _, _ = strings.Cut(volStr, " ")
+	volStr = strings.TrimSpace(volStr)
+
+	volume, err := strconv.ParseFloat(volStr, 64)
+	if err != nil {
+		volume = -1
+	}
+
+	return int(volume * 100), muted, nil
+}
+
+const (
+	PipewireDefaultInputKey  = "default.configured.audio.source"
+	PipewireDefaultOutputKey = "default.configured.audio.sink"
+)
+
+func getDefaultSinkAndSource() (defaultSourceName, defaultSinkName string, err error) {
+	cmd := exec.Command(PwDumpCommand, "Metadata")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", "", err
+	}
+
+	dump := PipewireDumpMetadata{}
+	err = json.Unmarshal(output, &dump)
+
+	for _, metadata := range dump {
+		for _, entry := range metadata.Metadata {
+			switch entry.Key {
+			case PipewireDefaultInputKey:
+				defaultSourceName = entry.Value.Name
+			case PipewireDefaultOutputKey:
+				defaultSinkName = entry.Value.Name
+			}
+		}
+	}
+
+	return defaultSourceName, defaultSinkName, nil
+}
+
+func GetDevices() ([]PipewireDevice, error) {
+	cmd := exec.Command(PwDumpCommand, "Node")
+	output, err := cmd.Output()
+	if err != nil {
+		return []PipewireDevice{}, err
+	}
+
+	dump := PipewireDumpNode{}
+	err = json.Unmarshal(output, &dump)
+	if err != nil {
+		return []PipewireDevice{}, err
+	}
+
+	defaultSinkName, defaultSourceName, err := getDefaultSinkAndSource()
+	if err != nil {
+		return []PipewireDevice{}, err
+	}
+
+	var devices []PipewireDevice
+	for _, node := range dump {
+		if node.Info.Props.MediaClass == PipewireTypeSink || node.Info.Props.MediaClass == PipewireTypeSource {
+			var volume int
+			var muted bool
+			volume, muted, err = getVolumeState(node.ID)
+
+			device := PipewireDevice{
+				ID:           node.ID,
+				Description:  node.Info.Props.NodeDescription,
+				PipewireType: node.Info.Props.MediaClass,
+				Volume:       volume,
+				Muted:        muted,
+				Selected:     node.Info.Props.NodeName == defaultSinkName || node.Info.Props.NodeName == defaultSourceName,
+			}
+
+			devices = append(devices, device)
+		}
+	}
+
+	return devices, nil
+}
+
+func SetDefaultDevice(deviceId int) error {
+	cmd := exec.Command(WpCtlCommand, "set-default", strconv.Itoa(deviceId))
+	return runCommand(cmd)
+}
+
+func ToggleMute(deviceId int) error {
+	cmd := exec.Command(WpCtlCommand, "set-mute", strconv.Itoa(deviceId), "toggle")
+	return runCommand(cmd)
+}
+
+func SetVolume(deviceId int, volumeDiffPercentage int) error {
+	var sign string
+	if volumeDiffPercentage >= 0 {
+		sign = "+"
+	} else {
+		sign = "-"
+	}
+	cmd := exec.Command(WpCtlCommand, "set-volume", strconv.Itoa(deviceId), fmt.Sprintf("%d%%%s", volumeDiffPercentage, sign))
+	return runCommand(cmd)
+}

--- a/internal/providers/wireplumber/setup.go
+++ b/internal/providers/wireplumber/setup.go
@@ -1,0 +1,223 @@
+// Package wireplumber allows to configure audio devices.
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"os/exec"
+	"sort"
+	"strconv"
+	"time"
+
+	_ "embed"
+
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
+)
+
+var (
+	Name       = "wireplumber"
+	NamePretty = "Wireplumber"
+)
+
+//go:embed README.md
+var readme string
+
+type Config struct {
+	common.Config  `koanf:",squash"`
+	VolumeStepSize int `koanf:"volume-step-size" desc:"volume step size (in percent, max: 100)" default:"5"`
+}
+
+var (
+	config *Config
+)
+
+func Setup() {
+	start := time.Now()
+
+	config = &Config{
+		Config: common.Config{
+			Icon:     "multimedia-volume-control-symbolic",
+			MinScore: 50,
+		},
+		VolumeStepSize: 5,
+	}
+
+	common.LoadConfig(Name, config)
+
+	if config.NamePretty != "" {
+		NamePretty = config.NamePretty
+	}
+
+	if config.VolumeStepSize >= 100 {
+		slog.Error(Name, "volume-step-size", config.VolumeStepSize)
+	}
+
+	slog.Info(Name, "loaded", time.Since(start))
+}
+
+func executableExists(command string) bool {
+	p, err := exec.LookPath(command)
+
+	if p == "" || err != nil {
+		slog.Info(Name, "available", fmt.Sprintf("%s not found. disabling.", command))
+		return false
+	}
+
+	return true
+}
+
+func Available() bool {
+	return executableExists("pw-dump") && executableExists("wpctl")
+}
+
+func PrintDoc() {
+	fmt.Println(readme)
+	fmt.Println()
+	util.PrintConfig(Config{}, Name)
+}
+
+const ActionIncreaseVolume = "increase_volume"
+const ActionDecreaseVolume = "decrease_volume"
+const ActionToggleMute = "toggle_mute"
+const ActionSetDefaultDevice = "set_default_device"
+
+func Activate(single bool, identifier, action string, query string, args string, format uint8, conn net.Conn) {
+	switch action {
+	case ActionIncreaseVolume:
+		deviceId, err := strconv.Atoi(identifier)
+		if err != nil {
+			slog.Error(Name, "invalid deviceId", err)
+			return
+		}
+
+		SetVolume(deviceId, config.VolumeStepSize)
+
+		return
+	case ActionDecreaseVolume:
+		deviceId, err := strconv.Atoi(identifier)
+		if err != nil {
+			slog.Error(Name, "invalid deviceId", err)
+			return
+		}
+
+		SetVolume(deviceId, -config.VolumeStepSize)
+
+		return
+	case ActionToggleMute:
+		deviceId, err := strconv.Atoi(identifier)
+		if err != nil {
+			slog.Error(Name, "invalid deviceId", err)
+			return
+		}
+
+		ToggleMute(deviceId)
+
+		return
+	case ActionSetDefaultDevice:
+		deviceId, err := strconv.Atoi(identifier)
+		if err != nil {
+			slog.Error(Name, "invalid deviceId", err)
+			return
+		}
+
+		SetDefaultDevice(deviceId)
+		return
+	default:
+		slog.Error(Name, "activate", fmt.Sprintf("unknown action: %s", action))
+		return
+	}
+}
+
+const (
+	IconSink        = "audio-volume-high-symbolic"
+	IconSinkMuted   = "audio-volume-muted-symbolic"
+	IconSource      = "microphone-sensitivity-high-symbolic"
+	IconSourceMuted = "microphone-sensitivity-muted-symbolic"
+)
+
+func Query(conn net.Conn, query string, _ bool, exact bool, _ uint8) []*pb.QueryResponse_Item {
+	start := time.Now()
+	entries := []*pb.QueryResponse_Item{}
+
+	devices, err := GetDevices()
+	if err != nil {
+		slog.Error(Name, "query", err)
+		return entries
+	}
+	// sort to move the currently selected in/outputs to the top
+	// only relevant if the search query is empty
+	sort.Slice(devices, func(i, j int) bool {
+		if devices[i].Selected && !devices[j].Selected {
+			return true
+		}
+
+		return devices[i].PipewireType == PipewireTypeSink
+	})
+	for _, dev := range devices {
+		score, positions, start := common.FuzzyScore(query, dev.Description, exact)
+
+		var usageScore int32
+
+		var icon string
+		if dev.PipewireType == PipewireTypeSink {
+			if dev.Muted {
+				icon = IconSinkMuted
+			} else {
+				icon = IconSink
+			}
+		} else {
+			if dev.Muted {
+				icon = IconSourceMuted
+			} else {
+				icon = IconSource
+			}
+		}
+
+		actions := []string{ActionSetDefaultDevice, ActionIncreaseVolume, ActionDecreaseVolume, ActionToggleMute}
+
+		info := fmt.Sprintf("Volume: %d%%", dev.Volume)
+		if dev.Muted {
+			info += " (Muted)"
+		}
+
+		if dev.Selected {
+			info += " ✓"
+		}
+
+		if usageScore != 0 || score > config.MinScore || query == "" {
+			entries = append(entries, &pb.QueryResponse_Item{
+				Identifier: strconv.Itoa(dev.ID),
+				Score:      score,
+				Text:       dev.Description,
+				Subtext:    info,
+				Icon:       icon,
+				Provider:   Name,
+				Actions:    actions,
+				Fuzzyinfo: &pb.QueryResponse_Item_FuzzyInfo{
+					Start:     start,
+					Field:     "text",
+					Positions: positions,
+				},
+				Type: pb.QueryResponse_REGULAR,
+			})
+		}
+	}
+
+	slog.Debug(Name, "query", time.Since(start))
+	return entries
+}
+
+func Icon() string {
+	return config.Icon
+}
+
+func HideFromProviderlist() bool {
+	return config.HideFromProviderlist
+}
+
+func State(provider string) *pb.ProviderStateResponse {
+	return &pb.ProviderStateResponse{}
+}


### PR DESCRIPTION
Hey,

this PR adds a new provider for controlling audio inputs/outputs on Linux with [WirePlumber](https://wiki.archlinux.org/title/WirePlumber).

This should probably support most modern Linux distributions by default as they all use `wireplumber` and `pipewire`.

I can also add a pull request at `walker` to add default keybindings for it if desired, I used the following:

```toml
wireplumber = [
  { action = "set_default_device", label = "Set as default", default = true, bind = "Return" },
  { action = "increase_volume", label = "Increase volume", bind = "ctrl i" },
  { action = "decrease_volume", label = "Decrease volume", bind = "ctrl d" },
  { action = "toggle_mute", label = "Toggle mute", bind = "ctrl m" },
]
```

Example Screenshot from `walker`:
<img width="728" height="653" alt="Screenshot from 2026-01-31 15-52-27" src="https://github.com/user-attachments/assets/05e536f2-df46-4322-8742-80e06e6116f5" />


Cheers