### PR TITLE
install service without exec bit

### DIFF
--- a/cmd/elephant/elephant.go
+++ b/cmd/elephant/elephant.go
@@ -62,7 +62,7 @@ WantedBy=graphical-session.target
 							`
 
 							if !common.FileExists(file) {
-								err := os.WriteFile(file, []byte(data), 0o755)
+								err := os.WriteFile(file, []byte(data), 0o644)
 								if err != nil {
 									slog.Error("service", "enable write file", err)
 								}


### PR DESCRIPTION
systemd warns on the service file being executable.