### PR TITLE
archlinuxpkgs: add `explicit_only` option and outdated packages support

### DIFF
--- a/internal/providers/archlinuxpkgs/README.md
+++ b/internal/providers/archlinuxpkgs/README.md
@@ -8,7 +8,7 @@ Find, install and delete packages. Including AUR.
 - find AUR packages
 - install packages
 - list installed packages (explicitly or not).
-- detect outdated packages.
+- detect and update outdated packages.
 - remove packages
 - clear all done items
 

--- a/internal/providers/archlinuxpkgs/README.md
+++ b/internal/providers/archlinuxpkgs/README.md
@@ -7,10 +7,12 @@ Find, install and delete packages. Including AUR.
 - find official packages
 - find AUR packages
 - install packages
-- list all exclusively installed packages
+- list installed packages (explicitly or not).
+- detect outdated packages.
 - remove packages
 - clear all done items
 
 #### Requirements
 
 - `yay` or `paru` for AUR
+- [`checkupadtes`](https://man.archlinux.org/man/extra/pacman-contrib/checkupdates.8.en) (optional) to safely check for official repository updates without requiring a database sync.

--- a/internal/providers/archlinuxpkgs/package.go
+++ b/internal/providers/archlinuxpkgs/package.go
@@ -18,6 +18,7 @@ type Package struct {
 	Repository     string
 	Version        string
 	Installed      bool
+	Outdated       bool
 	FullInfo       string
 	URL            string
 	URLPath        string

--- a/internal/providers/archlinuxpkgs/package_gen.go
+++ b/internal/providers/archlinuxpkgs/package_gen.go
@@ -227,6 +227,12 @@ func (z *Package) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "Installed")
 				return
 			}
+		case "Outdated":
+			z.Outdated, err = dc.ReadBool()
+			if err != nil {
+				err = msgp.WrapError(err, "Outdated")
+				return
+			}
 		case "FullInfo":
 			z.FullInfo, err = dc.ReadString()
 			if err != nil {
@@ -294,9 +300,9 @@ func (z *Package) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *Package) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 14
+	// map header, size 15
 	// write "Name"
-	err = en.Append(0x8e, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	err = en.Append(0x8f, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
 	if err != nil {
 		return
 	}
@@ -343,6 +349,16 @@ func (z *Package) EncodeMsg(en *msgp.Writer) (err error) {
 	err = en.WriteBool(z.Installed)
 	if err != nil {
 		err = msgp.WrapError(err, "Installed")
+		return
+	}
+	// write "Outdated"
+	err = en.Append(0xa8, 0x4f, 0x75, 0x74, 0x64, 0x61, 0x74, 0x65, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteBool(z.Outdated)
+	if err != nil {
+		err = msgp.WrapError(err, "Outdated")
 		return
 	}
 	// write "FullInfo"
@@ -441,9 +457,9 @@ func (z *Package) EncodeMsg(en *msgp.Writer) (err error) {
 // MarshalMsg implements msgp.Marshaler
 func (z *Package) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 14
+	// map header, size 15
 	// string "Name"
-	o = append(o, 0x8e, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	o = append(o, 0x8f, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
 	o = msgp.AppendString(o, z.Name)
 	// string "Description"
 	o = append(o, 0xab, 0x44, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e)
@@ -457,6 +473,9 @@ func (z *Package) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Installed"
 	o = append(o, 0xa9, 0x49, 0x6e, 0x73, 0x74, 0x61, 0x6c, 0x6c, 0x65, 0x64)
 	o = msgp.AppendBool(o, z.Installed)
+	// string "Outdated"
+	o = append(o, 0xa8, 0x4f, 0x75, 0x74, 0x64, 0x61, 0x74, 0x65, 0x64)
+	o = msgp.AppendBool(o, z.Outdated)
 	// string "FullInfo"
 	o = append(o, 0xa8, 0x46, 0x75, 0x6c, 0x6c, 0x49, 0x6e, 0x66, 0x6f)
 	o = msgp.AppendString(o, z.FullInfo)
@@ -535,6 +554,12 @@ func (z *Package) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "Installed")
 				return
 			}
+		case "Outdated":
+			z.Outdated, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Outdated")
+				return
+			}
 		case "FullInfo":
 			z.FullInfo, bts, err = msgp.ReadStringBytes(bts)
 			if err != nil {
@@ -603,6 +628,6 @@ func (z *Package) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *Package) Msgsize() (s int) {
-	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 12 + msgp.StringPrefixSize + len(z.Description) + 11 + msgp.StringPrefixSize + len(z.Repository) + 8 + msgp.StringPrefixSize + len(z.Version) + 10 + msgp.BoolSize + 9 + msgp.StringPrefixSize + len(z.FullInfo) + 4 + msgp.StringPrefixSize + len(z.URL) + 8 + msgp.StringPrefixSize + len(z.URLPath) + 11 + msgp.StringPrefixSize + len(z.Maintainer) + 10 + msgp.StringPrefixSize + len(z.Submitter) + 9 + msgp.IntSize + 11 + msgp.Float64Size + 15 + msgp.Int64Size + 13 + msgp.Int64Size
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 12 + msgp.StringPrefixSize + len(z.Description) + 11 + msgp.StringPrefixSize + len(z.Repository) + 8 + msgp.StringPrefixSize + len(z.Version) + 10 + msgp.BoolSize + 9 + msgp.BoolSize + 9 + msgp.StringPrefixSize + len(z.FullInfo) + 4 + msgp.StringPrefixSize + len(z.URL) + 8 + msgp.StringPrefixSize + len(z.URLPath) + 11 + msgp.StringPrefixSize + len(z.Maintainer) + 10 + msgp.StringPrefixSize + len(z.Submitter) + 9 + msgp.IntSize + 11 + msgp.Float64Size + 15 + msgp.Int64Size + 13 + msgp.Int64Size
 	return
 }

--- a/internal/providers/archlinuxpkgs/setup.go
+++ b/internal/providers/archlinuxpkgs/setup.go
@@ -50,6 +50,7 @@ const (
 	ActionVisitURL      = "visit_url"
 	ActionRefresh       = "refresh"
 	ActionRemove        = "remove"
+	ActionUpdate        = "update"
 	ActionShowInstalled = "show_installed"
 	ActionShowOutdated  = "show_outdated"
 	ActionShowAll       = "show_all"
@@ -59,6 +60,7 @@ type Config struct {
 	common.Config        `koanf:",squash"`
 	CommandInstall       string `koanf:"command_install" desc:"default command for AUR packages to install. supports %VALUE%." default:"yay -S %VALUE%"`
 	CommandRemove        string `koanf:"command_remove" desc:"default command to remove packages. supports %VALUE%." default:"sudo pacman -R %VALUE%"`
+	CommandUpdate        string `koanf:"command_update" desc:"default command to update outdated packages." default:"yay -Suy"`
 	AutoWrapWithTerminal bool   `koanf:"auto_wrap_with_terminal" desc:"automatically wraps the command with terminal" default:"true"`
 	ExplicitOnly         bool   `koanf:"explicit_only" desc:"when filtering installed packages, show only explicitly installed packages, not dependencies" default:"true"`
 }
@@ -134,6 +136,7 @@ func LoadConfig() {
 		},
 		CommandInstall:       fmt.Sprintf("%s -S %s", helper, "%VALUE%"),
 		CommandRemove:        fmt.Sprintf("%s -R %s", helper, "%VALUE%"),
+		CommandUpdate:        fmt.Sprintf("%s -Suy", helper),
 		AutoWrapWithTerminal: true,
 		ExplicitOnly: true,
 	}
@@ -227,6 +230,8 @@ func Activate(single bool, identifier, action string, query string, args string,
 		pkgcmd = config.CommandInstall
 	case ActionRemove:
 		pkgcmd = config.CommandRemove
+	case ActionUpdate:
+		pkgcmd = config.CommandUpdate
 	default:
 		slog.Error(Name, "activate", fmt.Sprintf("unknown action: %s", action))
 		return
@@ -344,14 +349,22 @@ func HideFromProviderlist() bool {
 func State(provider string) *pb.ProviderStateResponse {
     actions := []string{ActionRefresh}
 
-    switch filter {
-    case Installed:
-        actions = append(actions, ActionShowAll, ActionShowOutdated)
-    case Outdated:
-        actions = append(actions, ActionShowInstalled, ActionShowAll)
-    default: // All
-        actions = append(actions, ActionShowInstalled, ActionShowOutdated)
-    }
+	outdatedIsEmpty := len(outdated) != 0
+
+	switch filter {
+	case Installed:
+		actions = append(actions, ActionShowAll)
+	case Outdated:
+		actions = append(actions, ActionShowInstalled, ActionShowAll)
+	default: // All
+		actions = append(actions, ActionShowInstalled)
+	}
+	if outdatedIsEmpty && filter != Outdated {
+		actions = append(actions, ActionShowOutdated)
+	}
+	if outdatedIsEmpty {
+		actions = append(actions, ActionUpdate)
+	}
 
     return &pb.ProviderStateResponse{
         Actions: actions,
@@ -490,16 +503,31 @@ func getOutdated() {
 
     aurCmd := exec.Command(detectHelper(), "-Qu", "--aur")
     aurOut, aurErr := aurCmd.CombinedOutput()
-    if aurErr != nil {
-        slog.Error(Name, "outdated", aurErr)
+	if aurErr != nil {
+		// yay -Qu --aur return 1 when no updates are required
+		if exitErr, ok := aurErr.(*exec.ExitError); ok && exitErr.ExitCode() != 1 {
+			slog.Error(Name, "outdated", offErr)
+        }
+    }
+
+	var installedSet map[string]struct{}
+    if config.ExplicitOnly {
+        installedSet = make(map[string]struct{}, len(installed))
+        for _, pkg := range installed {
+            installedSet[pkg] = struct{}{}
+        }
     }
 
     for _, out := range [][]byte{offOut, aurOut} {
         for line := range strings.Lines(string(out)) {
             fields := strings.Fields(line)
             if len(fields) > 0 {
-                outdated = append(outdated, fields[0])
-            }
-        }
+                name := fields[0]
+                _, inInstalled := installedSet[name]
+                if !config.ExplicitOnly || inInstalled {
+                    outdated = append(outdated, name)
+                }
+            }        
+		}
     }
 }

--- a/internal/providers/archlinuxpkgs/setup.go
+++ b/internal/providers/archlinuxpkgs/setup.go
@@ -50,6 +50,7 @@ type Config struct {
 	CommandInstall       string `koanf:"command_install" desc:"default command for AUR packages to install. supports %VALUE%." default:"yay -S %VALUE%"`
 	CommandRemove        string `koanf:"command_remove" desc:"default command to remove packages. supports %VALUE%." default:"sudo pacman -R %VALUE%"`
 	AutoWrapWithTerminal bool   `koanf:"auto_wrap_with_terminal" desc:"automatically wraps the command with terminal" default:"true"`
+	ExplicitOnly         bool   `koanf:"explicit_only" desc:"when filtering installed packages, show only explicitly installed packages, not dependencies" default:"true"`
 }
 
 type AURPackage struct {
@@ -124,6 +125,7 @@ func LoadConfig() {
 		CommandInstall:       fmt.Sprintf("%s -S %s", helper, "%VALUE%"),
 		CommandRemove:        fmt.Sprintf("%s -R %s", helper, "%VALUE%"),
 		AutoWrapWithTerminal: true,
+		ExplicitOnly: true,
 	}
 
 	common.LoadConfig(Name, config)
@@ -420,8 +422,15 @@ func setupAURPkgs() {
 
 func getInstalled() {
 	installed = []string{}
+	
+	var cmd *exec.Cmd
 
-	cmd := exec.Command("pacman", "-Qe")
+	if config.ExplicitOnly {
+		cmd = exec.Command("pacman", "-Qe")
+	} else {
+		cmd = exec.Command("pacman", "-Q")
+	}
+
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		slog.Error(Name, "installed", err)

--- a/internal/providers/archlinuxpkgs/setup.go
+++ b/internal/providers/archlinuxpkgs/setup.go
@@ -22,12 +22,21 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
+type Filter int
+
+const (
+    All      Filter = iota
+    Installed
+    Outdated
+)
+
 var (
 	Name          = "archlinuxpkgs"
 	NamePretty    = "Arch Linux Packages"
 	config        *Config
 	installed     = []string{}
-	installedOnly = false
+	outdated      = []string{}
+	filter Filter = All
 	cacheFile     = common.CacheFile("archlinuxpkgs.json")
 	cachedData    = newCachedData()
 )
@@ -42,6 +51,7 @@ const (
 	ActionRefresh       = "refresh"
 	ActionRemove        = "remove"
 	ActionShowInstalled = "show_installed"
+	ActionShowOutdated  = "show_outdated"
 	ActionShowAll       = "show_all"
 )
 
@@ -144,6 +154,7 @@ func Setup() {
 
 func setup() {
 	getInstalled()
+	getOutdated()
 	getOfficialPkgs()
 	setupAURPkgs()
 
@@ -198,11 +209,14 @@ func Activate(single bool, identifier, action string, query string, args string,
 		setup()
 		return
 	case ActionShowAll:
-		installedOnly = false
+		filter = All
 		return
 	case ActionShowInstalled:
-		installedOnly = true
+		filter = Installed
 		return
+	case ActionShowOutdated:
+        filter = Outdated
+        return
 	}
 
 	name := cachedData.Packages[identifier].Name
@@ -251,9 +265,9 @@ func Query(conn net.Conn, query string, single bool, exact bool, _ uint8) []*pb.
 	}
 
 	for k, v := range cachedData.Packages {
-		if installedOnly && !v.Installed {
-			continue
-		}
+		if (filter == Installed && !v.Installed) || (filter == Outdated && !v.Outdated) {
+            continue
+        }
 
 		state := []string{}
 		a := []string{}
@@ -270,9 +284,15 @@ func Query(conn net.Conn, query string, single bool, exact bool, _ uint8) []*pb.
 			a = append(a, "visit_url")
 		}
 
-		subtext := fmt.Sprintf("[%s]", strings.ToLower(v.Repository))
-		if v.Installed {
-			subtext = fmt.Sprintf("[%s] [installed]", strings.ToLower(v.Repository))
+		repo := fmt.Sprintf("[%s]", strings.ToLower(v.Repository))
+		var subtext string
+		switch {
+		case v.Installed && v.Outdated:
+			subtext = repo + " [installed] [outdated]"
+		case v.Installed:
+			subtext = repo + " [installed]"
+		default:
+			subtext = repo
 		}
 
 		e := &pb.QueryResponse_Item{
@@ -322,17 +342,20 @@ func HideFromProviderlist() bool {
 }
 
 func State(provider string) *pb.ProviderStateResponse {
-	actions := []string{ActionRefresh}
+    actions := []string{ActionRefresh}
 
-	if installedOnly {
-		actions = append(actions, ActionShowAll)
-	} else {
-		actions = append(actions, ActionShowInstalled)
-	}
+    switch filter {
+    case Installed:
+        actions = append(actions, ActionShowAll, ActionShowOutdated)
+    case Outdated:
+        actions = append(actions, ActionShowInstalled, ActionShowAll)
+    default: // All
+        actions = append(actions, ActionShowInstalled, ActionShowOutdated)
+    }
 
-	return &pb.ProviderStateResponse{
-		Actions: actions,
-	}
+    return &pb.ProviderStateResponse{
+        Actions: actions,
+    }
 }
 
 func getOfficialPkgs() {
@@ -365,6 +388,7 @@ func getOfficialPkgs() {
 		case strings.HasPrefix(line, "Name"):
 			e.Name = strings.TrimSpace(strings.Split(line, ":")[1])
 			e.Installed = slices.Contains(installed, e.Name)
+			e.Outdated = slices.Contains(outdated, e.Name)
 		case strings.HasPrefix(line, "Description"):
 			e.Description = strings.TrimSpace(strings.Split(line, ":")[1])
 		case strings.HasPrefix(line, "Version"):
@@ -414,6 +438,7 @@ func setupAURPkgs() {
 			Version:     pkg.Version,
 			Repository:  "aur",
 			Installed:   slices.Contains(installed, pkg.Name),
+			Outdated:    slices.Contains(outdated, pkg.Name),
 			URL:         pkg.URL,
 			FullInfo:    pkg.toFullInfo(),
 		}
@@ -442,4 +467,39 @@ func getInstalled() {
 			installed = append(installed, fields[0])
 		}
 	}
+}
+
+func getOutdated() {
+    outdated = []string{}
+
+    var offCmd *exec.Cmd
+    if _, err := exec.LookPath("checkupdates"); err == nil {
+        offCmd = exec.Command("checkupdates")
+    } else {
+        offCmd = exec.Command("pacman", "-Qu")
+    }
+
+	offOut, offErr := offCmd.CombinedOutput()
+    if offErr != nil {
+		// checkupdates return 2 when no updates are required
+		if exitErr, ok := offErr.(*exec.ExitError); ok && exitErr.ExitCode() != 2 {
+			slog.Error(Name, "outdated", offErr)
+        }
+    }
+
+
+    aurCmd := exec.Command(detectHelper(), "-Qu", "--aur")
+    aurOut, aurErr := aurCmd.CombinedOutput()
+    if aurErr != nil {
+        slog.Error(Name, "outdated", aurErr)
+    }
+
+    for _, out := range [][]byte{offOut, aurOut} {
+        for line := range strings.Lines(string(out)) {
+            fields := strings.Fields(line)
+            if len(fields) > 0 {
+                outdated = append(outdated, fields[0])
+            }
+        }
+    }
 }


### PR DESCRIPTION
Implements the ideas from https://github.com/abenz1267/elephant/discussions/217

- Adds an `explicit_only` config option (default: `true`) to filter out dependency packages
- Adds outdated package detection for both official repos and AUR, respecting `explicit_only`
- Adds action to update outdated packages