### PR TITLE
fix(menus): prevent panic when provider does not contain `:menu_name`

### DIFF
--- a/internal/providers/menus/setup.go
+++ b/internal/providers/menus/setup.go
@@ -300,7 +300,12 @@ func HideFromProviderlist() bool {
 }
 
 func State(provider string) *pb.ProviderStateResponse {
-	menu := strings.Split(provider, ":")[1]
+	_, menu, found := strings.Cut(provider, ":")
+
+	if !found || menu == "" {
+		slog.Error("invalid provider format: expected `menus:your_menu`", "provider", provider)
+		return &pb.ProviderStateResponse{}
+	}
 
 	if val, ok := common.Menus[menu]; ok {
 		if val.Parent != "" {
@@ -310,6 +315,7 @@ func State(provider string) *pb.ProviderStateResponse {
 		}
 	}
 
+	slog.Error("menu source not found", "provider", provider, "menu", menu)
 	return &pb.ProviderStateResponse{}
 }
 


### PR DESCRIPTION
When calling `walker -m menus`, instead of `walker -m menus:my_menu`, elephant would panic because the provider name did not contain any `:` to correctly split on.

Add checks to handle incorrectly formatted provider name, logging an error for the user. Additionally log an error when the given menu name is not found.