### PR TITLE
feat(providers): add new playerctl plugin

### DIFF
--- a/internal/providers/playerctl/README.md
+++ b/internal/providers/playerctl/README.md
@@ -1,0 +1,7 @@
+### Elephant playerctl
+
+Control media/audio players with playerctl.
+
+#### Requirements
+
+- `playerctl`

--- a/internal/providers/playerctl/makefile
+++ b/internal/providers/playerctl/makefile
@@ -1,0 +1,39 @@
+DESTDIR ?=
+CONFIGDIR = $(DESTDIR)/etc/xdg/elephant/providers
+
+GO_BUILD_FLAGS = -buildvcs=false -buildmode=plugin -trimpath
+PLUGIN_NAME = playerctl.so
+
+.PHONY: all build install uninstall clean
+
+all: build
+
+build:
+	go build $(GO_BUILD_FLAGS)
+
+install: build
+	# Install plugin
+	install -Dm 755 $(PLUGIN_NAME) $(CONFIGDIR)/$(PLUGIN_NAME)
+
+uninstall:
+	rm -f $(CONFIGDIR)/$(PLUGIN_NAME)
+
+clean:
+	go clean
+	rm -f $(PLUGIN_NAME)
+
+dev-install: install
+
+help:
+	@echo "Available targets:"
+	@echo "  all       - Build the plugin (default)"
+	@echo "  build     - Build the plugin"
+	@echo "  install   - Install the plugin"
+	@echo "  uninstall - Remove installed plugin"
+	@echo "  clean     - Clean build artifacts"
+	@echo "  help      - Show this help"
+	@echo ""
+	@echo "Variables:"
+	@echo "  DESTDIR   - Destination directory for staged installs"
+	@echo ""
+	@echo "Note: This builds a Go plugin (.so file) for elephant"

--- a/internal/providers/playerctl/setup.go
+++ b/internal/providers/playerctl/setup.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	_ "embed"
+
+	"fmt"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+	"os/exec"
+
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
+)
+
+var (
+	Name       = "playerctl"
+	NamePretty = "Playerctl"
+	config  *Config
+)
+
+//go:embed README.md
+var readme string
+
+const (
+	ActionPlayPause   = "toggle_pause"
+	ActionNext        = "next"
+	ActionPrev        = "prev"
+	ActionVolUp       = "vol_up"
+	ActionVolDown     = "vol_down"
+	ActionSeekForward = "seek_forward"
+	ActionSeekBack    = "seek_back"
+)
+
+var actions = []string{ActionPlayPause, ActionNext, ActionPrev, ActionVolUp, ActionVolDown, ActionSeekForward, ActionSeekBack}
+
+type Config struct {
+	common.Config          `koanf:",squash"`
+	VolStep        float64 `koanf:"vol_step"  desc:"volume step size" default:"0.05"`
+	SeekStep       int     `koanf:"seek_step" desc:"seek step in seconds" default:"5"`
+}
+
+func Setup() {
+	LoadConfig()
+}
+
+func LoadConfig() {
+	config = &Config{
+		Config: common.Config{},
+		VolStep:  0.05,
+		SeekStep: 5,
+	}
+
+	common.LoadConfig(Name, config)
+}
+
+func Available() bool {
+	p, err := exec.LookPath("playerctl")
+
+	if p == "" || err != nil {
+		slog.Info(Name, "available", "playerctl not found. disabling.")
+		return false
+	}
+
+	return true
+}
+
+func PrintDoc(write bool) {
+	if !write {
+		fmt.Println(readme)
+		fmt.Println()
+	}
+	util.PrintConfig(config, Name, write)
+}
+
+func Activate(single bool, identifier, action string, query string, args string, format uint8, conn net.Conn) {
+	volStep   := fmt.Sprintf("%g+", config.VolStep)
+	volStepD  := fmt.Sprintf("%g-", config.VolStep)
+	seekStep  := fmt.Sprintf("%d+", config.SeekStep)
+	seekStepB := fmt.Sprintf("%d-", config.SeekStep)
+
+	switch action {
+	case ActionPlayPause:
+		exec.Command("playerctl", "-p", identifier, "play-pause").Run()
+	case ActionNext:
+		exec.Command("playerctl", "-p", identifier, "next").Run()
+	case ActionPrev:
+		exec.Command("playerctl", "-p", identifier, "previous").Run()
+	case ActionVolUp:
+		exec.Command("playerctl", "-p", identifier, "volume", volStep).Run()
+	case ActionVolDown:
+		exec.Command("playerctl", "-p", identifier, "volume", volStepD).Run()
+	case ActionSeekForward:
+		exec.Command("playerctl", "-p", identifier, "position", seekStep).Run()
+	case ActionSeekBack:
+		exec.Command("playerctl", "-p", identifier, "position", seekStepB).Run()
+	default:
+		slog.Warn(Name, "activate", "unknown action", "action", action)
+	}
+}
+
+func Query(conn net.Conn, query string, _ bool, exact bool, _ uint8) []*pb.QueryResponse_Item {
+	players, err := exec.Command("playerctl", "-l").Output()
+	if err != nil {
+		slog.Error(Name, "query", "failed to list players", "err", err)
+		return nil
+	}
+
+	playerList := strings.Fields(string(players))
+	if len(playerList) == 0 {
+		return nil
+	}
+
+	type result struct {
+		title  string
+		artist string
+		status string
+		player string
+	}
+
+	resultsCh := make(chan result, len(playerList))
+
+	var wg sync.WaitGroup
+	for _, player := range playerList {
+		wg.Add(1)
+		go func(playerName string) {
+			defer wg.Done()
+
+			meta, err := exec.Command("playerctl", "-p", playerName, "metadata", "--format",
+				"{{xesam:title}}\n{{xesam:artist}}\n{{status}}").Output()
+			if err != nil {
+				slog.Warn(Name, "player", playerName, "err", err)
+				return
+			}
+
+			lines := strings.SplitN(strings.TrimSpace(string(meta)), "\n", 3)
+			if len(lines) < 3 {
+				return
+			}
+
+			resultsCh <- result{
+				player: playerName,
+				title:  lines[0],
+				artist: lines[1],
+				status: lines[2],
+			}
+		}(player)
+	}
+
+	// Close channel once all goroutines finish
+	go func() {
+		wg.Wait()
+		close(resultsCh)
+	}()
+
+	entries := []*pb.QueryResponse_Item{}
+	for r := range resultsCh {
+		if strings.EqualFold(r.status, "") {
+			continue
+		}
+		
+		icon := "media-playback-start"
+		if strings.EqualFold(r.status, "Playing") {
+		    icon = "media-playback-pause"
+		}
+
+		entries = append(entries, &pb.QueryResponse_Item{
+			Identifier: r.player,
+			Text:       r.title,
+			Type:       pb.QueryResponse_REGULAR,
+			Subtext:    fmt.Sprintf("%s · %s", r.artist, r.status),
+			Icon: icon,
+			Actions: actions,
+			Provider: Name,
+		})
+	}
+
+	return entries
+}
+func Icon() string {
+	return "media-playback-start"
+}
+
+func HideFromProviderlist() bool {
+	return config.HideFromProviderlist
+}
+
+func State(provider string) *pb.ProviderStateResponse {
+	return &pb.ProviderStateResponse{}
+}

--- a/internal/providers/playerctl/setup.go
+++ b/internal/providers/playerctl/setup.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	_ "embed"
+	"strconv"
 
 	"fmt"
 	"log/slog"
 	"net"
+	"os/exec"
 	"strings"
 	"sync"
-	"os/exec"
 
 	"github.com/abenz1267/elephant/v2/internal/util"
 	"github.com/abenz1267/elephant/v2/pkg/common"
@@ -25,13 +26,16 @@ var (
 var readme string
 
 const (
-	ActionPlayPause   = "toggle_pause"
-	ActionNext        = "next"
-	ActionPrev        = "prev"
-	ActionVolUp       = "vol_up"
-	ActionVolDown     = "vol_down"
-	ActionSeekForward = "seek_forward"
-	ActionSeekBack    = "seek_back"
+	ActionPlayPause     = "toggle_pause"
+	ActionNext          = "next"
+	ActionPrev          = "prev"
+	ActionVolUp         = "vol_up"
+	ActionVolDown       = "vol_down"
+	ActionToggleMute    = "toggle_mute"
+	ActionSeekForward   = "seek_forward"
+	ActionSeekBack      = "seek_back"
+	ActionToggleShuffle = "toggle_shuffle"
+	ActionToggleLoop    = "toggle_loop"
 )
 
 var actions = []string{ActionPlayPause, ActionNext, ActionPrev, ActionVolUp, ActionVolDown, ActionSeekForward, ActionSeekBack}
@@ -92,10 +96,44 @@ func Activate(single bool, identifier, action string, query string, args string,
 		exec.Command("playerctl", "-p", identifier, "volume", volStep).Run()
 	case ActionVolDown:
 		exec.Command("playerctl", "-p", identifier, "volume", volStepD).Run()
+	case ActionToggleMute:
+		get_vol, err := exec.Command("playerctl", "-p", identifier, "volume").Output()
+		if err != nil {
+			slog.Error(Name, "activate", "Failed to get volume", "action", action)
+		}
+
+		vol, _ := strconv.ParseFloat(string(get_vol), 64)
+		
+		if vol == 0.0 {
+			vol = 1.0
+		} else {
+			vol = 0.0
+		}
+
+		exec.Command("playerctl", "-p", identifier, "volume", fmt.Sprintf("%g", vol))
 	case ActionSeekForward:
 		exec.Command("playerctl", "-p", identifier, "position", seekStep).Run()
 	case ActionSeekBack:
 		exec.Command("playerctl", "-p", identifier, "position", seekStepB).Run()
+	case ActionToggleShuffle:
+		exec.Command("playerctl", "-p", identifier, "shuffle", "Toggle").Run()
+	case ActionToggleLoop:
+		loop, err := exec.Command("playerctl", "-p", identifier, "loop").Output()
+		if err != nil {
+			slog.Error(Name, "activate", "Failed to get loop state", "action", action)
+		}
+
+		loop_str := string(loop)
+		switch loop_str {
+		case "none":
+			loop_str = "Track"
+		case "Track":
+			loop_str = "Playlist"
+		case "Playlist":
+			loop_str = "none"
+		}
+
+		exec.Command("playerctl", "-p", identifier, "loop", loop_str).Run()
 	default:
 		slog.Warn(Name, "activate", "unknown action", "action", action)
 	}

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -15,6 +15,7 @@ with lib; let
     "desktopapplications"
     "files"
     "menus"
+    "playerctl"
     "providerlist"
     "runner"
     "snippets"

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -15,6 +15,7 @@ with lib; let
     "desktopapplications"
     "files"
     "menus"
+    "playerctl"
     "providerlist"
     "runner"
     "snippets"


### PR DESCRIPTION
Adds a provider that uses playerctl to allow controlling media playback, namely pause/play, volume and seeking and skipping. PFA a sample screenshot
<img width="2240" height="1400" alt="image" src="https://github.com/user-attachments/assets/69bf0f4e-f261-4d9c-b10d-a436a1232396" />
