### PR TITLE
fix(desktopapplications): split XDG_CURRENT_DESKTOP by colon for Ubuntu support

### DIFF
--- a/internal/providers/desktopapplications/parser.go
+++ b/internal/providers/desktopapplications/parser.go
@@ -88,8 +88,8 @@ func parseFile(path, l, ll string) (*DesktopFile, error) {
 		}
 	}
 
-	shouldShow := (len(f.NotShowIn) == 0 || !slices.Contains(f.NotShowIn, desktop)) &&
-		(len(f.OnlyShowIn) == 0 || slices.Contains(f.OnlyShowIn, desktop)) &&
+	shouldShow := (len(f.NotShowIn) == 0 || !containsAny(f.NotShowIn, desktops)) &&
+		(len(f.OnlyShowIn) == 0 || containsAny(f.OnlyShowIn, desktops)) &&
 		!f.Hidden && !f.NoDisplay
 
 	if shouldShow && f.Name == "" {

--- a/internal/providers/desktopapplications/query.go
+++ b/internal/providers/desktopapplications/query.go
@@ -13,7 +13,23 @@ import (
 	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
-var desktop = os.Getenv("XDG_CURRENT_DESKTOP")
+var desktops = splitDesktops(os.Getenv("XDG_CURRENT_DESKTOP"))
+
+func splitDesktops(val string) []string {
+	if val == "" {
+		return nil
+	}
+	return strings.Split(val, ":")
+}
+
+func containsAny(haystack, needles []string) bool {
+	for _, n := range needles {
+		if slices.Contains(haystack, n) {
+			return true
+		}
+	}
+	return false
+}
 
 func Query(conn net.Conn, query string, _ bool, exact bool, _ uint8) []*pb.QueryResponse_Item {
 	start := time.Now()
@@ -25,7 +41,7 @@ func Query(conn net.Conn, query string, _ bool, exact bool, _ uint8) []*pb.Query
 	}
 
 	for k, v := range files {
-		if len(v.NotShowIn) != 0 && slices.Contains(v.NotShowIn, desktop) || len(v.OnlyShowIn) != 0 && !slices.Contains(v.OnlyShowIn, desktop) || v.Hidden || v.NoDisplay {
+		if len(v.NotShowIn) != 0 && containsAny(v.NotShowIn, desktops) || len(v.OnlyShowIn) != 0 && !containsAny(v.OnlyShowIn, desktops) || v.Hidden || v.NoDisplay {
 			continue
 		}
 

--- a/internal/providers/desktopapplications/query.go
+++ b/internal/providers/desktopapplications/query.go
@@ -13,14 +13,7 @@ import (
 	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
 
-var desktops = splitDesktops(os.Getenv("XDG_CURRENT_DESKTOP"))
-
-func splitDesktops(val string) []string {
-	if val == "" {
-		return nil
-	}
-	return strings.Split(val, ":")
-}
+var desktops = strings.Split(os.Getenv("XDG_CURRENT_DESKTOP"), ":")
 
 func containsAny(haystack, needles []string) bool {
 	for _, n := range needles {

--- a/internal/providers/desktopapplications/setup.go
+++ b/internal/providers/desktopapplications/setup.go
@@ -104,11 +104,13 @@ func Setup() {
 	}
 
 	if config.WMIntegration {
-		switch os.Getenv("XDG_CURRENT_DESKTOP") {
-		case "niri":
-			wmi = Niri{}
-		case "Hyprland":
-			wmi = Hyprland{}
+		for _, d := range desktops {
+			switch d {
+			case "niri":
+				wmi = Niri{}
+			case "Hyprland":
+				wmi = Hyprland{}
+			}
 		}
 	}
 


### PR DESCRIPTION
On Ubuntu, XDG_CURRENT_DESKTOP is set to "ubuntu:GNOME" (colon-separated list). The current code compares the entire string against OnlyShowIn / NotShowIn values, so "GNOME" never matches "ubuntu:GNOME" and system apps like Settings are filtered out.

The XDG Desktop Entry spec mandates that XDG_CURRENT_DESKTOP is a colon-separated list of desktop identifiers. This patch splits it accordingly and checks if *any* component matches.

Closes #232 