### PR TITLE
fix(nix): set GOROOT in devShell to prevent GVM conflict

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,9 @@
             protobuf
             protoc-gen-go
           ];
+          shellHook = ''
+            export GOROOT="${pkgs.go}/share/go"
+          '';
         };
       });
 


### PR DESCRIPTION
## Problem

I'm using impure nix env (ubuntu) with Go Version Manager installed (GVM)

When using `nix develop --build`, the build failed with version mismatch errors:

      compile: version "go1.24.6" does not match go tool version "go1.25.4"

  The nix devShell puts go1.25.4 first in `PATH`, but GVM's environment sets `GOROOT` to its own  go1.24.6 installation. This causes the go binary (1.25.4) to find a mismatched standard library (1.24.6), breaking compilation.

  ## Fix

  Added a `shellHook` in the devShell that explicitly sets `GOROOT` to the nix-provided Go installation, overriding any value set by GVM or other Go version managers.

  ## Affected users

  Users who have GVM (or any Go version manager that sets `GOROOT`) installed alongside Nix.