### PR TITLE
fix(clipboard): use atomic.Bool for paused flag to prevent data race

### DIFF
--- a/internal/providers/clipboard/setup.go
+++ b/internal/providers/clipboard/setup.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 	"unicode/utf8"
@@ -54,7 +55,7 @@ var unicodedata string
 var symbolsdata string
 
 var (
-	paused       bool
+	paused       atomic.Bool
 	saveFileChan = make(chan struct{})
 )
 
@@ -309,7 +310,7 @@ func handleChange() {
 	scanner := bufio.NewScanner(stdout)
 
 	for scanner.Scan() {
-		if paused {
+		if paused.Load() {
 			continue
 		}
 
@@ -608,9 +609,9 @@ func Activate(single bool, identifier, action string, query string, args string,
 			}()
 		}
 	case ActionPause:
-		paused = true
+		paused.Store(true)
 	case ActionUnpause:
-		paused = false
+		paused.Store(false)
 	case ActionImagesOnly:
 		currentMode = ImagesOnly
 		nextMode = ActionTextOnly
@@ -943,7 +944,7 @@ func State(provider string) *pb.ProviderStateResponse {
 		actions = append(actions, ActionRemoveAll)
 	}
 
-	if paused {
+	if paused.Load() {
 		states = append(states, "paused")
 		actions = append(actions, ActionUnpause)
 	} else {


### PR DESCRIPTION
## Summary

Replace the plain `bool` variable `paused` with `sync/atomic.Bool` to eliminate a data race between `Activate()` (writes) and `handleChange()` / `State()` (reads from separate goroutines).

**Full-disclosure:** I mostly used **Claude Code** for this as I'm not a proficient in Go as I am with Ruby/Python, but I did check the code and reviewed it as would review my code.

## Reproducing the race

Build the clipboard plugin with the race detector and run elephant:

```bash
cd internal/providers/clipboard
go build -race -buildmode=plugin -trimpath
# copy clipboard.so to your provider directory, restart elephant
```

Then trigger pause/unpause (via the clipboard provider actions) while clipboard changes are happening. The race detector will report a data race on `paused`:

```
WARNING: DATA RACE
Write at ... setup.go:XXX (Activate -> paused = true)
Previous read at ... setup.go:XXX (handleChange -> if paused {)
```

## Changes

- `var paused bool` → `var paused atomic.Bool`
- `paused = true/false` → `paused.Store(true/false)`
- `if paused {` → `if paused.Load() {`

## Test plan

- [ ] Pause/unpause clipboard via actions
- [ ] Verify clipboard stops/resumes watching after pause/unpause