### PR TITLE
fix(clipboard): initialize symbols before goroutines to prevent map race

### DIFF
--- a/internal/providers/clipboard/setup.go
+++ b/internal/providers/clipboard/setup.go
@@ -101,12 +101,12 @@ func Setup() {
 
 	loadFromFile()
 
-	go handleChange()
-	go handleSaveToFile()
-
 	if config.IgnoreSymbols {
 		setupUnicodeSymbols()
 	}
+
+	go handleChange()
+	go handleSaveToFile()
 
 	if config.AutoCleanup != 0 {
 		go cleanup()
@@ -231,9 +231,7 @@ func setupUnicodeSymbols() {
 		}
 
 		toUse := string(rune(codePoint))
-		mu.Lock()
 		symbols[toUse] = struct{}{}
-		mu.Unlock()
 	}
 
 	// symbols
@@ -245,11 +243,9 @@ func setupUnicodeSymbols() {
 	}
 
 	for _, v := range ldml.Annotations.Annotation {
-		mu.Lock()
 		if _, ok := symbols[v.CP]; !ok {
 			symbols[v.CP] = struct{}{}
 		}
-		mu.Unlock()
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix a data race on the `symbols` map. Currently `go handleChange()` starts before `setupUnicodeSymbols()` runs, so the goroutine can read the map while it's being written — a race condition that can crash Go.

**Full-disclosure:** I mostly used **Claude Code** for this as I'm not a proficient in Go as I am with Ruby/Python, but I did check the code and reviewed it as would review my code.

## Reproducing the race

Build the clipboard plugin with the race detector:

```bash
cd internal/providers/clipboard
go build -race -buildmode=plugin -trimpath
# copy clipboard.so to your provider directory, restart elephant
```

With `ignore_symbols = true` in your clipboard config, copy any text immediately after elephant starts. The `handleChange()` goroutine reads `symbols[text]` in `updateText()` while `setupUnicodeSymbols()` is still writing to the map. The race detector will report:

```
WARNING: DATA RACE
Write at ... setup.go:XXX (setupUnicodeSymbols -> symbols[toUse] = struct{}{})
Previous read at ... setup.go:XXX (updateText -> if _, ok := symbols[text])
```

In production (without `-race`), concurrent map read+write can cause a hard crash:

```
fatal error: concurrent map read and map write
```

## Changes

- Move `setupUnicodeSymbols()` call before `go handleChange()` in `Setup()` so the map is fully populated before any reader starts
- Remove 4 unnecessary `mu.Lock()/Unlock()` calls in `setupUnicodeSymbols()` — no longer needed since initialization completes before goroutines start

## Test plan

- [ ] Open elephant with `ignore_symbols = true`, verify symbols are still filtered from clipboard
- [ ] Copy a unicode symbol, verify it doesn't appear in clipboard history