### PR TITLE
fix(clipboard): replace log.Fatal with slog.Error in handleChange

### DIFF
--- a/internal/providers/clipboard/setup.go
+++ b/internal/providers/clipboard/setup.go
@@ -299,11 +299,13 @@ func handleChange() {
 	cmd := exec.Command("wl-paste", "--watch", "echo", "clipboard-changed")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		log.Fatal("Error creating stdout pipe:", err)
+		slog.Error(Name, "handleChange", "failed to create stdout pipe", "error", err)
+		return
 	}
 
 	if err := cmd.Start(); err != nil {
-		log.Fatal("Error starting wl-paste watch:", err)
+		slog.Error(Name, "handleChange", "failed to start wl-paste watch", "error", err)
+		return
 	}
 
 	scanner := bufio.NewScanner(stdout)


### PR DESCRIPTION
## Summary

`log.Fatal` in `handleChange()` calls `os.Exit(1)`, killing the entire elephant process if `wl-paste --watch` fails to start. A clipboard error shouldn't crash the whole application launcher.

**Full-disclosure:** I mostly used **Claude Code** for this as I'm not a proficient in Go as I am with Ruby/Python, but I did check the code and reviewed it as would review my code.

## Reproducing the problem

Simulate a `wl-paste` failure by temporarily renaming it (or running elephant in a non-Wayland session where `wl-paste` isn't available but the clipboard plugin is still enabled):

```bash
# Option 1: rename wl-paste temporarily
sudo mv /usr/bin/wl-paste /usr/bin/wl-paste.bak
elephant  # entire process exits immediately with log.Fatal

# Option 2: check the Available() function
# Available() checks for wl-paste, so it normally prevents loading.
# But if wl-paste disappears AFTER Available() runs (e.g., package
# update removes it mid-session), handleChange() will log.Fatal and
# kill the entire launcher — all providers, not just clipboard.
```

With this fix, elephant continues running and all other providers remain functional. Only the clipboard watcher goroutine exits, and the error is logged via `slog.Error`.

## Changes

Replace two `log.Fatal` calls with `slog.Error` + `return` so only the clipboard watcher goroutine exits.

## Test plan

- [ ] On a Wayland session, verify clipboard watching works normally
- [ ] Temporarily make `wl-paste` unavailable, verify elephant logs the error but continues running