### PR TITLE
feat(protonpass): add Proton Pass provider via pass-cli

### DIFF
--- a/internal/providers/protonpass/Makefile
+++ b/internal/providers/protonpass/Makefile
@@ -1,0 +1,39 @@
+DESTDIR ?=
+CONFIGDIR = $(DESTDIR)/etc/xdg/elephant/providers
+
+GO_BUILD_FLAGS = -buildvcs=false -buildmode=plugin -trimpath
+PLUGIN_NAME = protonpass.so
+
+.PHONY: all build install uninstall clean
+
+all: build
+
+build:
+	go build $(GO_BUILD_FLAGS)
+
+install: build
+	# Install plugin
+	install -Dm 755 $(PLUGIN_NAME) $(CONFIGDIR)/$(PLUGIN_NAME)
+
+uninstall:
+	rm -f $(CONFIGDIR)/$(PLUGIN_NAME)
+
+clean:
+	go clean
+	rm -f $(PLUGIN_NAME)
+
+dev-install: install
+
+help:
+	@echo "Available targets:"
+	@echo "  all       - Build the plugin (default)"
+	@echo "  build     - Build the plugin"
+	@echo "  install   - Install the plugin"
+	@echo "  uninstall - Remove installed plugin"
+	@echo "  clean     - Clean build artifacts"
+	@echo "  help      - Show this help"
+	@echo ""
+	@echo "Variables:"
+	@echo "  DESTDIR   - Destination directory for staged installs"
+	@echo ""
+	@echo "Note: This builds a Go plugin (.so file) for elephant"

--- a/internal/providers/protonpass/README.md
+++ b/internal/providers/protonpass/README.md
@@ -1,0 +1,77 @@
+### Elephant Proton Pass
+
+Access your Proton Pass vaults.
+
+#### Requirements
+
+- `pass-cli` (Proton Pass CLI — <https://protonpass.github.io/pass-cli/>)
+- must be logged in (`pass-cli test` exits 0)
+- `wl-copy` (for clipboard)
+
+#### Setup
+
+Install and authenticate pass-cli, then add a prefix in your walker config:
+
+```toml
+[[providers.prefixes]]
+prefix = "*"
+provider = "protonpass"
+```
+
+#### Actions & keybinds
+
+Add this to your walker config to bind all three actions:
+
+```toml
+# ~/.config/walker/config.toml
+[providers.actions]
+protonpass = [
+  { action = "copy_password", label = "copy password", default = true, bind = "Return" },
+  { action = "copy_username", label = "copy username", bind = "shift Return" },
+  { action = "copy_2fa",      label = "copy 2fa",      bind = "ctrl Return" },
+]
+```
+
+| Keybind      | Action                                   |
+| ------------ | ---------------------------------------- |
+| Return       | Copy password                            |
+| Shift+Return | Copy username / email                    |
+| Ctrl+Return  | Copy TOTP (only shown when item has 2FA) |
+
+#### Configuration
+
+```toml
+# ~/.config/elephant/protonpass.toml
+
+vaults = ["Personal"]        # vault names to index; leave empty to use pass-cli default
+notify = true                # desktop notification after copying
+clear_after = 5              # clear clipboard after X seconds (0 to disable)
+```
+
+Multiple vaults:
+
+```toml
+vaults = ["Personal", "Work"]
+```
+
+#### Walker theme — subtext visibility
+
+By default some walker themes (including omarchy) hide the subtext row entirely.
+The subtext shows the email/username and URL for each item. To enable it, add this
+to your user theme override (e.g. `~/.config/omarchy/current/theme/walker.css`):
+
+```css
+.item-subtext {
+  font-size: 13px !important;
+  opacity: 0.6 !important;
+  min-height: unset !important;
+  margin: 0px !important;
+  padding: 2px 0 !important;
+}
+```
+
+#### Notes
+
+- Passwords are **not** cached in memory. Each copy fetches from pass-cli on demand.
+- Items are indexed at startup. Restart elephant to pick up new/deleted items.
+- Only `Active` login items are indexed; notes, credit cards, aliases and SSH keys are skipped.

--- a/internal/providers/protonpass/protonpass.go
+++ b/internal/providers/protonpass/protonpass.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os/exec"
+	"time"
+)
+
+// --- Parse-time structs ---
+// These mirror the JSON returned by `pass-cli item list --output json`.
+// They are only used inside initItems() and are not kept in memory afterward.
+
+// passItemList is the top-level wrapper object returned by `pass-cli item list`.
+type passItemList struct {
+	Items []passRawItem `json:"items"`
+}
+
+// passRawItem is one entry in the listing.
+// We capture share_id so we can address this item in later commands without
+// relying on pass-cli's configured default vault.
+type passRawItem struct {
+	ID      string         `json:"id"`
+	ShareID string         `json:"share_id"`
+	Content passRawContent `json:"content"`
+	State   string         `json:"state"` // "Active", "Trashed", etc.
+}
+
+// passRawContent holds the item's title and type-specific payload.
+type passRawContent struct {
+	Title   string       `json:"title"`
+	Content passRawInner `json:"content"`
+}
+
+// passRawInner is a tagged union: the JSON object uses item-type strings as
+// keys ("Login", "Note", "CreditCard", …). We only care about "Login".
+// Using a pointer means json.Unmarshal leaves Login as nil when the key is
+// absent, so we can skip non-login items without extra error handling.
+type passRawInner struct {
+	Login *passRawLogin `json:"Login"`
+}
+
+// passRawLogin holds the credential fields for a login item.
+// Password is present in the listing JSON but is NOT forwarded to the cached
+// struct — see the security note on ProtonPassItem below.
+type passRawLogin struct {
+	Email    string   `json:"email"`
+	Username string   `json:"username"`
+	Password string   `json:"password"` // parsed here, then discarded
+	URLs     []string `json:"urls"`
+	TOTPUri  string   `json:"totp_uri"` // non-empty means item has a TOTP field
+}
+
+// --- Cached struct ---
+// ProtonPassItem is what we actually keep in memory after parsing.
+//
+// Security note: pass-cli item list returns all passwords in the listing JSON
+// (unlike 1password's `op`, which only returns metadata). We intentionally do
+// not store the password here. Passwords are fetched one at a time via
+// `pass-cli item view --field password` only when the user requests them,
+// limiting how long plaintext credentials live in the process heap.
+type ProtonPassItem struct {
+	ID      string
+	ShareID string // vault identifier; required to address this item explicitly
+	Title   string
+	User    string // email if non-empty, otherwise username
+	URL     string // first URL from the item, shown as subtext hint
+	HasTOTP bool   // true if totp_uri was non-empty at parse time
+}
+
+// checkAvailable blocks until `pass-cli test` exits 0, meaning the user is
+// authenticated. It retries every second so elephant waits gracefully instead
+// of crashing if the CLI session hasn't started yet.
+func checkAvailable() {
+	for {
+		cmd := exec.Command("pass-cli", "test")
+
+		if err := cmd.Run(); err != nil {
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		return
+	}
+}
+
+// initItems populates cachedItems by calling `pass-cli item list` once per
+// configured vault.
+//
+// If config.Vaults is empty, a single call is made with no vault argument,
+// which uses pass-cli's configured default vault. This lets users with a
+// single vault skip the vaults config entirely.
+func initItems() {
+	checkAvailable()
+
+	cachedItems = []ProtonPassItem{}
+
+	// If no vaults are configured, treat a single empty string as "use
+	// pass-cli's default" — the loop still runs exactly once.
+	vaults := config.Vaults
+	if len(vaults) == 0 {
+		vaults = []string{""}
+	}
+
+	for _, vault := range vaults {
+		// The vault name is a positional argument that must appear before any
+		// flags: `pass-cli item list [VAULT_NAME] [--output FORMAT]`.
+		// We build the args slice conditionally to avoid passing an empty string
+		// as the vault name.
+		args := []string{"item", "list", "--output", "json"}
+		if vault != "" {
+			args = []string{"item", "list", vault, "--output", "json"}
+		}
+
+		cmd := exec.Command("pass-cli", args...)
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			slog.Error(Name, "init", err, "msg", string(output))
+			continue
+		}
+
+		var list passItemList
+		if err := json.Unmarshal(output, &list); err != nil {
+			slog.Error(Name, "parse", err, "msg", string(output))
+			continue
+		}
+
+		for _, raw := range list.Items {
+			// Skip trashed/deleted items and any non-login types (notes,
+			// credit cards, aliases, SSH keys, …).
+			if raw.State != "Active" || raw.Content.Content.Login == nil {
+				continue
+			}
+
+			login := raw.Content.Content.Login
+
+			// Use email as the display username when present; fall back to
+			// the username field. Proton Pass treats them as separate fields.
+			user := login.Email
+			if user == "" {
+				user = login.Username
+			}
+
+			// Take only the first URL; items can have many but we only need
+			// one for the subtext hint in the search results.
+			url := ""
+			if len(login.URLs) > 0 {
+				url = login.URLs[0]
+			}
+
+			cachedItems = append(cachedItems, ProtonPassItem{
+				ID:      raw.ID,
+				ShareID: raw.ShareID,
+				Title:   raw.Content.Title,
+				User:    user,
+				URL:     url,
+				HasTOTP: login.TOTPUri != "",
+				// Password is intentionally not stored here.
+			})
+		}
+	}
+}

--- a/internal/providers/protonpass/setup.go
+++ b/internal/providers/protonpass/setup.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"os/exec"
+	"strings"
+	"time"
+
+	_ "embed"
+
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
+)
+
+var (
+	Name        = "protonpass"
+	NamePretty  = "Proton Pass"
+	config      *Config
+	cachedItems []ProtonPassItem // populated by initItems(), read by Query() and Activate()
+)
+
+var readme string
+
+type Config struct {
+	common.Config `koanf:",squash"`
+	// Vaults lists the vault names to index. Matches the 1password convention.
+	// Leave empty to use whichever vault pass-cli has set as default.
+	Vaults     []string `koanf:"vaults" desc:"vault names to index" default:"[\"Personal\"]"`
+	Notify     bool     `koanf:"notify" desc:"send a desktop notification after copying" default:"true"`
+	ClearAfter int      `koanf:"clear_after" desc:"clear the clipboard after X seconds (0 to disable)" default:"5"`
+}
+
+func LoadConfig() {
+	config = &Config{
+		Config: common.Config{
+			Icon:     "proton-pass",
+			MinScore: 20,
+		},
+		Vaults:     []string{"Personal"},
+		Notify:     true,
+		ClearAfter: 5,
+	}
+
+	common.LoadConfig(Name, config)
+}
+
+func Setup() {
+	LoadConfig()
+
+	if config.NamePretty != "" {
+		NamePretty = config.NamePretty
+	}
+
+	initItems()
+}
+
+// Available reports whether pass-cli is installed. Elephant calls this before
+// loading the plugin; returning false disables the provider entirely.
+func Available() bool {
+	p, err := exec.LookPath("pass-cli")
+	if p == "" || err != nil {
+		slog.Info(Name, "available", "pass-cli not found.")
+		return false
+	}
+
+	return true
+}
+
+func PrintDoc(write bool) {
+	if !write {
+		fmt.Println(readme)
+		fmt.Println()
+	}
+
+	util.PrintConfig(config, Name, write)
+}
+
+const (
+	ActionCopyPassword = "copy_password"
+	ActionCopyUsername = "copy_username"
+	ActionCopy2FA      = "copy_2fa"
+)
+
+// notifyAndClear optionally sends a desktop notification and then waits
+// ClearAfter seconds before wiping the clipboard. It is always called as
+// `go notifyAndClear(msg)` so it runs in the background without blocking Activate.
+func notifyAndClear(msg string) {
+	if config.Notify {
+		exec.Command("notify-send", "-i", "proton-pass", "Proton Pass", msg).Run()
+	}
+
+	if config.ClearAfter > 0 {
+		// time.Duration is an int64 of nanoseconds, so we must multiply by
+		// time.Second to get the right unit.
+		time.Sleep(time.Duration(config.ClearAfter) * time.Second)
+		exec.Command("wl-copy", "--clear").Run()
+	}
+}
+
+// findItem looks up a cached item by its ID. Returns a zero-value and false
+// if not found. Using a named return for the bool makes the call sites read
+// naturally: `if item, ok := findItem(id); ok { … }`.
+func findItem(id string) (ProtonPassItem, bool) {
+	for _, v := range cachedItems {
+		if v.ID == id {
+			return v, true
+		}
+	}
+
+	return ProtonPassItem{}, false
+}
+
+// Activate is called when the user selects an action on a result.
+// identifier is the item ID (set as Identifier in Query's response).
+// action is one of the ActionCopy* constants above.
+func Activate(single bool, identifier, action string, query string, args string, format uint8, conn net.Conn) {
+	switch action {
+	case ActionCopyPassword:
+		item, ok := findItem(identifier)
+		if !ok {
+			slog.Error(Name, "copy password", "item not found in cache", "id", identifier)
+			return
+		}
+
+		// Fetch the password on-demand rather than reading it from cache.
+		// We pass --share-id so the command is unambiguous across vaults.
+		cmd := exec.Command("pass-cli", "item", "view",
+			"--share-id", item.ShareID,
+			"--item-id", identifier,
+			"--field", "password",
+		)
+
+		// cmd.Output() captures stdout only; stderr goes to /dev/null.
+		// If the command fails, the error describes why.
+		output, err := cmd.Output()
+		if err != nil {
+			slog.Error(Name, "get password", err)
+			exec.Command("notify-send", "error fetching password.").Run()
+			return
+		}
+
+		// The field output includes a trailing newline
+		password := strings.TrimSpace(string(output))
+
+		// "--" signals end of flags; prevents passwords starting with "-"
+		// from being misinterpreted as wl-copy flags.
+		if err := exec.Command("wl-copy", "--sensitive", "--", password).Run(); err != nil {
+			slog.Error(Name, "copy password", err)
+			exec.Command("notify-send", "-i", "proton-pass", "Proton Pass", "error copying password.").Run()
+			return
+		}
+
+		go notifyAndClear("Password copied — " + item.Title)
+
+	case ActionCopyUsername:
+		item, ok := findItem(identifier)
+		if !ok {
+			slog.Error(Name, "copy username", "item not found in cache", "id", identifier)
+			return
+		}
+
+		if err := exec.Command("wl-copy", "--", item.User).Run(); err != nil {
+			slog.Error(Name, "copy username", err)
+			exec.Command("notify-send", "-i", "proton-pass", "Proton Pass", "error copying username.").Run()
+			return
+		}
+
+		go notifyAndClear("Username copied — " + item.Title)
+
+	case ActionCopy2FA:
+		item, ok := findItem(identifier)
+		if !ok {
+			slog.Error(Name, "copy 2fa", "item not found in cache", "id", identifier)
+			return
+		}
+
+		cmd := exec.Command("pass-cli", "item", "totp",
+			"--share-id", item.ShareID,
+			"--item-id", identifier,
+			"--output", "json",
+		)
+
+		output, err := cmd.Output()
+		if err != nil {
+			slog.Error(Name, "get totp", err)
+			exec.Command("notify-send", "error fetching TOTP.").Run()
+			return
+		}
+
+		// The TOTP response is a map of field-name → code. Items can have
+		// multiple TOTP fields; the standard login one is always keyed "totp".
+		// Example: {"totp": "235775", "totp_uri": "235775"}
+		var totpData map[string]string
+		if err := json.Unmarshal(output, &totpData); err != nil {
+			slog.Error(Name, "parse totp", err)
+			return
+		}
+
+		code, ok := totpData["totp"]
+		if !ok || code == "" {
+			exec.Command("notify-send", "no TOTP field found on this item.").Run()
+			return
+		}
+
+		if err := exec.Command("wl-copy", "--sensitive", "--", code).Run(); err != nil {
+			slog.Error(Name, "copy totp", err)
+			exec.Command("notify-send", "-i", "proton-pass", "Proton Pass", "error copying TOTP.").Run()
+			return
+		}
+
+		go notifyAndClear("TOTP copied — " + item.Title)
+	}
+}
+
+func Query(conn net.Conn, query string, single bool, exact bool, _ uint8) []*pb.QueryResponse_Item {
+	start := time.Now()
+
+	entries := []*pb.QueryResponse_Item{}
+
+	// k is the index, v is a copy of the ProtonPassItem at that index.
+	for k, v := range cachedItems {
+		// First action is the default (Return). Username and 2FA are bound
+		// via walker's [providers.actions] config — see README.
+		actions := []string{ActionCopyPassword, ActionCopyUsername}
+		title := v.Title
+		if v.HasTOTP {
+			actions = append(actions, ActionCopy2FA)
+			title = "[2FA] " + title
+		}
+
+		subtext := v.User
+		if v.URL != "" {
+			if subtext != "" {
+				subtext += " — " + v.URL
+			} else {
+				subtext = v.URL
+			}
+		}
+
+		e := &pb.QueryResponse_Item{
+			Identifier: v.ID,
+			Text:       title,
+			Subtext:    subtext,
+			Icon:       config.Icon,
+			Provider:   Name,
+			Actions:    actions,
+			// Score when no query is set: items appear in list order.
+			// 100_000 - k gives earlier items a higher score, preserving
+			// the order returned by pass-cli (usually alphabetical).
+			Score: int32(100_000 - k),
+		}
+
+		if query != "" {
+			score, positions, startPos := common.FuzzyScore(query, v.Title, exact)
+
+			e.Score = score
+			e.Fuzzyinfo = &pb.QueryResponse_Item_FuzzyInfo{
+				Start:     startPos,
+				Field:     "text",
+				Positions: positions,
+			}
+		}
+
+		// Drop items that scored below the configured threshold when a query
+		// is active. When there's no query, include everything.
+		if query == "" || e.Score > config.MinScore {
+			entries = append(entries, e)
+		}
+	}
+
+	slog.Debug(Name, "query", time.Since(start))
+
+	return entries
+}
+
+func Icon() string {
+	return config.Icon
+}
+
+func HideFromProviderlist() bool {
+	return config.HideFromProviderlist
+}
+
+func State(provider string) *pb.ProviderStateResponse {
+	return &pb.ProviderStateResponse{}
+}


### PR DESCRIPTION
## Adds Proton Pass provider

This adds a new provider for [Proton Pass](https://protonpass.github.io/pass-cli/) that wraps the official `pass-cli` (currently in beta, paid Proton plan required). Mirrors the existing 1password and bitwarden providers in structure and behaviour.

### Actions

Three actions matching the 1password convention:

- `copy_password` (default)
- `copy_username` — uses the email field if present, falls back to username
- `copy_2fa` — only exposed on items with a configured TOTP

### Notes

- I’m happy to update walker resources/config.toml with the provider.actions if the pr is accepted.
- I’m also happy to update the files when/if proton pass-cli has modifications.
- I’ve used Claude code to help me write the go code

### Tested (currently using)

- Arch Linux + Hyprland + walker, ~600 entries

Thank you :)