### PR TITLE
fix(runner): skip error for unnecessary PATH

### DIFF
--- a/internal/providers/runner/setup.go
+++ b/internal/providers/runner/setup.go
@@ -75,6 +75,10 @@ func Setup() {
 		}
 
 		for p := range strings.SplitSeq(os.Getenv("PATH"), ":") {
+			if _, err := os.Stat(p); err != nil {
+				continue
+			}
+			
 			walkFn := func(path string, d fs.DirEntry, err error) error {
 				info, serr := os.Stat(path)
 				if info == nil || serr != nil {


### PR DESCRIPTION
Avoid throwing errors for elements in PATH that are not needed by the runner, such as:

```bash
2026/05/11 12:23:21 ERROR runner load="stat /snap/bin: no such file or directory"
2026/05/11 12:23:21 ERROR runner load="stat /home/lucapattocchio/.dotnet/tools: no such file or directory"
```