### PR TITLE
nix: convert systemd service to user service

### DIFF
--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -282,35 +282,16 @@ in {
             cfg.provider.menus.lua))
       ];
 
-    systemd.services.elephant = mkIf cfg.installService {
+    systemd.user.services.elephant = mkIf cfg.installService {
       description = "Elephant launcher backend";
-      wantedBy = ["multi-user.target"];
-      after = ["network.target"];
+      after = ["graphical-session.target"];
+      partOf = ["graphical-session.target"];
+      wantedBy = ["default.target"];
 
       serviceConfig = {
-        Type = "simple";
-        User = cfg.user;
-        Group = cfg.group;
         ExecStart = "${cfg.package}/bin/elephant ${optionalString cfg.debug "--debug"}";
         Restart = "on-failure";
         RestartSec = 1;
-
-        # Security settings
-        NoNewPrivileges = true;
-        PrivateTmp = true;
-        ProtectSystem = "strict";
-        ProtectHome = true;
-        ReadWritePaths = [
-          "/var/lib/elephant"
-          "/tmp"
-        ];
-
-        # Clean up socket on stop
-        ExecStopPost = "${pkgs.coreutils}/bin/rm -f /tmp/elephant.sock";
-      };
-
-      environment = {
-        HOME = "/var/lib/elephant";
       };
     };
   };

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -286,7 +286,11 @@ in {
       description = "Elephant launcher backend";
       after = ["graphical-session.target"];
       partOf = ["graphical-session.target"];
-      wantedBy = ["default.target"];
+      wantedBy = ["graphical-session.target"];
+
+      unitConfig = {
+        ConditionEnvironment = "WAYLAND_DISPLAY";
+      };
 
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/elephant ${optionalString cfg.debug "--debug"}";


### PR DESCRIPTION
The current elephant service did not have access to the user profile and graphical session. I fixed this by switching to a user service. If wanted I could also make that an option instead and keep both ways.