### PR TITLE
feat(providers): add systempower and systempackage plugins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,12 +163,22 @@ jobs:
         echo "Building dnfpackages plugin for linux/amd64..."
         GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags="-s -w" -buildmode=plugin -o build/wireplumber-linux-amd64.so ./internal/providers/wireplumber
 
-    - name: Build playerctl plugin for linux/amd64
-      run: |
-        echo "Building dnfpackages plugin for linux/amd64..."
-        GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags="-s -w" -buildmode=plugin -o build/playerctl-linux-amd64.so ./internal/providers/playerctl
+- name: Build playerctl plugin for linux/amd64
+  run: |
+    echo "Building dnfpackages plugin for linux/amd64..."
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags="-s -w" -buildmode=plugin -o build/playerctl-linux-amd64.so ./internal/providers/playerctl
 
-    - name: Upload build artifacts
+- name: Build systempackage plugin for linux/amd64
+  run: |
+    echo "Building systempackage plugin for linux/amd64..."
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags="-s -w" -buildmode=plugin -o build/systempackage-linux-amd64.so ./internal/providers/systempackage
+
+- name: Build systempower plugin for linux/amd64
+  run: |
+    echo "Building systempower plugin for linux/amd64..."
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -ldflags="-s -w" -buildmode=plugin -o build/systempower-linux-amd64.so ./internal/providers/systempower
+
+- name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
         name: build-artifacts
@@ -269,10 +279,16 @@ jobs:
         # Archive wireplumber plugin
         tar -czf wireplumber-linux-amd64.tar.gz wireplumber-linux-amd64.so
 
-        # Archive playerctl plugin
-        tar -czf playerctl-linux-amd64.tar.gz playerctl-linux-amd64.so
+# Archive playerctl plugin
+tar -czf playerctl-linux-amd64.tar.gz playerctl-linux-amd64.so
 
-        echo "Build completed successfully!"
+# Archive systempackage plugin
+tar -czf systempackage-linux-amd64.tar.gz systempackage-linux-amd64.so
+
+# Archive systempower plugin
+tar -czf systempower-linux-amd64.tar.gz systempower-linux-amd64.so
+
+echo "Build completed successfully!"
         echo "Created archives:"
         ls -la *.tar.gz
 

--- a/internal/providers/systempackage/README.md
+++ b/internal/providers/systempackage/README.md
@@ -1,0 +1,20 @@
+### Elephant System Packages
+
+Cross-distro package management: search, install, remove, and show package info.
+
+#### Features
+
+- Supports 5 package managers: pacman (Arch), apt (Debian/Ubuntu), dnf (Fedora), zypper (openSUSE), apk (Alpine)
+- Fuzzy package search
+- Install / Remove / Show Info / System Update
+- Auto-detects available package manager
+- Safe package name handling via shell escaping
+
+#### Requirements
+
+- One of: `pacman`, `apt-get`, `dnf`, `zypper`, or `apk`
+
+#### Configuration
+
+- `icon` — icon name (default: `software-install`)
+- `min_score` — minimum fuzzy score (default: `20`)

--- a/internal/providers/systempackage/makefile
+++ b/internal/providers/systempackage/makefile
@@ -1,0 +1,36 @@
+DESTDIR ?=
+CONFIGDIR = $(DESTDIR)/etc/xdg/elephant/providers
+
+GO_BUILD_FLAGS = -buildvcs=false -buildmode=plugin -trimpath
+PLUGIN_NAME = systempackage.so
+
+.PHONY: all build install uninstall clean
+
+all: build
+
+build:
+	go build $(GO_BUILD_FLAGS)
+
+install: build
+	install -Dm 755 $(PLUGIN_NAME) $(CONFIGDIR)/$(PLUGIN_NAME)
+
+uninstall:
+	rm -f $(CONFIGDIR)/$(PLUGIN_NAME)
+
+clean:
+	go clean
+	rm -f $(PLUGIN_NAME)
+
+dev-install: install
+
+help:
+	@echo "Available targets:"
+	@echo "  all       - Build the plugin (default)"
+	@echo "  build     - Build the plugin"
+	@echo "  install   - Install the plugin"
+	@echo "  uninstall - Remove installed plugin"
+	@echo "  clean     - Clean build artifacts"
+	@echo "  help      - Show this help"
+	@echo ""
+	@echo "Variables:"
+	@echo "  DESTDIR   - Destination directory for staged installs"

--- a/internal/providers/systempackage/setup.go
+++ b/internal/providers/systempackage/setup.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"al.essio.dev/pkg/shellescape"
+	_ "embed"
+
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
+)
+
+var (
+	Name       = "systempackage"
+	NamePretty = "System Packages"
+	config     *Config
+)
+
+//go:embed README.md
+var readme string
+
+const (
+	ActionInstall = "install"
+	ActionRemove  = "remove"
+	ActionUpdate  = "update"
+	ActionInfo    = "info"
+)
+
+type Config struct {
+	common.Config `koanf:",squash"`
+}
+
+type PkgManager struct {
+	name       string
+	searchCmd  string // %s = query
+	installCmd string // %s = package names
+	removeCmd  string // %s = package names
+	updateCmd  string
+	infoCmd    string // %s = package name
+	queryCmd   string // %s = package name (installed check)
+}
+
+var managers = map[string]PkgManager{
+	"pacman": {
+		name: "pacman", searchCmd: "pacman -Ss --color=never '%s'",
+		installCmd: "sudo pacman -S --needed --noconfirm %s",
+		removeCmd:  "sudo pacman -Rns --noconfirm %s",
+		updateCmd:  "sudo pacman -Syu --noconfirm",
+		infoCmd:    "pacman -Si '%s'",
+		queryCmd:   "pacman -Q '%s'",
+	},
+	"apt": {
+		name: "apt", searchCmd: "apt-cache search --names-only '%s'",
+		installCmd: "sudo apt-get install -y %s",
+		removeCmd:  "sudo apt-get remove -y %s",
+		updateCmd:  "sudo apt-get update && sudo apt-get upgrade -y",
+		infoCmd:    "apt-cache show '%s'",
+		queryCmd:   "dpkg -s '%s'",
+	},
+	"dnf": {
+		name: "dnf", searchCmd: "dnf search '%s'",
+		installCmd: "sudo dnf install -y %s",
+		removeCmd:  "sudo dnf remove -y %s",
+		updateCmd:  "sudo dnf upgrade -y",
+		infoCmd:    "dnf info '%s'",
+		queryCmd:   "rpm -q '%s'",
+	},
+	"zypper": {
+		name: "zypper", searchCmd: "zypper --no-refresh --no-abbrev search '%s'",
+		installCmd: "sudo zypper install -y %s",
+		removeCmd:  "sudo zypper remove -y %s",
+		updateCmd:  "sudo zypper dup -y",
+		infoCmd:    "zypper info '%s'",
+		queryCmd:   "rpm -q '%s'",
+	},
+	"apk": {
+		name: "apk", searchCmd: "apk search '%s'",
+		installCmd: "sudo apk add %s",
+		removeCmd:  "sudo apk del %s",
+		updateCmd:  "sudo apk upgrade",
+		infoCmd:    "apk info '%s'",
+		queryCmd:   "apk info -e '%s'",
+	},
+}
+
+func detectPkgManager() string {
+	for _, bin := range []string{"pacman", "apt-get", "dnf", "zypper", "apk"} {
+		_, err := exec.LookPath(bin)
+		if err == nil {
+			switch bin {
+			case "pacman":
+				return "pacman"
+			case "apt-get":
+				return "apt"
+			case "dnf":
+				return "dnf"
+			case "zypper":
+				return "zypper"
+			case "apk":
+				return "apk"
+			}
+		}
+	}
+	return ""
+}
+
+func getManager() (string, PkgManager) {
+	manager := detectPkgManager()
+	if mgr, ok := managers[manager]; ok {
+		return manager, mgr
+	}
+	return "", PkgManager{}
+}
+
+func Setup() {
+	LoadConfig()
+
+	if config.NamePretty != "" {
+		NamePretty = config.NamePretty
+	}
+}
+
+func LoadConfig() {
+	config = &Config{
+		Config: common.Config{
+			Icon:     "software-install",
+			MinScore: 20,
+		},
+	}
+
+	common.LoadConfig(Name, config)
+}
+
+func Available() bool {
+	return detectPkgManager() != ""
+}
+
+func PrintDoc(write bool) {
+	if !write {
+		fmt.Println(readme)
+		fmt.Println()
+	}
+
+	util.PrintConfig(config, Name, write)
+}
+
+func Query(conn net.Conn, query string, single bool, _ bool, _ uint8) []*pb.QueryResponse_Item {
+	entries := []*pb.QueryResponse_Item{}
+
+	managerName, mgr := getManager()
+	if managerName == "" {
+		e := &pb.QueryResponse_Item{
+			Identifier: "none",
+			Text:       "No supported package manager found",
+			Subtext:    "Requires pacman, apt, dnf, zypper, or apk",
+			Icon:       config.Icon,
+			Provider:   Name,
+			Score:      200,
+			Type:       pb.QueryResponse_REGULAR,
+		}
+		return append(entries, e)
+	}
+
+	if query == "" {
+		entries = append(entries, &pb.QueryResponse_Item{
+			Identifier: "system-update",
+			Text:       "Update System Packages",
+			Subtext:    "Upgrade all installed packages",
+			Icon:       "software-update-available",
+			Provider:   Name,
+			Score:      200,
+			Type:       pb.QueryResponse_REGULAR,
+			Actions:    []string{ActionUpdate},
+		})
+		return entries
+	}
+
+	if len(query) >= 2 {
+		searchQuery := strings.ReplaceAll(query, "'", "'\\''")
+		cmd := exec.Command("sh", "-c", fmt.Sprintf(mgr.searchCmd, searchQuery))
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			slog.Error(Name, "search", err, "out", string(out))
+			return entries
+		}
+
+		lines := strings.Split(string(out), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+
+			var pkgName, desc string
+			switch managerName {
+			case "pacman":
+				parts := strings.SplitN(line, " ", 2)
+				if len(parts) < 2 {
+					continue
+				}
+				repoPkg := parts[0]
+				if idx := strings.Index(repoPkg, "/"); idx != -1 {
+					pkgName = repoPkg[idx+1:]
+				} else {
+					pkgName = repoPkg
+				}
+				desc = strings.TrimSpace(parts[1])
+			case "apt":
+				parts := strings.SplitN(line, " - ", 2)
+				if len(parts) < 2 {
+					continue
+				}
+				pkgName = strings.TrimSpace(parts[0])
+				desc = strings.TrimSpace(parts[1])
+			case "dnf":
+				parts := strings.Fields(line)
+				if len(parts) < 2 {
+					continue
+				}
+				pkgName = strings.TrimSpace(parts[0])
+				desc = strings.Join(parts[1:], " ")
+			case "zypper":
+				parts := strings.SplitN(line, "|", 3)
+				if len(parts) < 3 {
+					parts = strings.Fields(line)
+					if len(parts) < 2 {
+						continue
+					}
+				}
+				pkgName = strings.TrimSpace(parts[1])
+				desc = strings.TrimSpace(parts[len(parts)-1])
+			case "apk":
+				// Format: "pkgname-version description" or "pkg-name-1.2.3-r0 desc"
+				spaceIdx := strings.Index(line, " ")
+				var nameVer string
+				if spaceIdx != -1 {
+					nameVer = line[:spaceIdx]
+					desc = strings.TrimSpace(line[spaceIdx+1:])
+				} else {
+					nameVer = line
+				}
+				segments := strings.Split(nameVer, "-")
+				lastName := len(segments)
+				for lastName > 0 {
+					lastName--
+					if len(segments[lastName]) > 0 && segments[lastName][0] >= '0' && segments[lastName][0] <= '9' {
+						break
+					}
+				}
+				if lastName > 0 {
+					pkgName = strings.Join(segments[:lastName], "-")
+				} else {
+					pkgName = nameVer
+				}
+			}
+
+			if pkgName == "" {
+				continue
+			}
+
+			score, _, _ := common.FuzzyScore(query, pkgName, false)
+			if score > config.MinScore {
+				entries = append(entries, &pb.QueryResponse_Item{
+					Identifier: pkgName,
+					Text:       pkgName,
+					Subtext:    desc,
+					Icon:       config.Icon,
+					Provider:   Name,
+					Score:      score,
+					Type:       pb.QueryResponse_REGULAR,
+					Actions:    []string{ActionInstall, ActionInfo, ActionRemove},
+				})
+			}
+		}
+	}
+
+	return entries
+}
+
+func Activate(_ bool, identifier, action string, _ string, _ string, _ uint8, _ net.Conn) {
+	_, mgr := getManager()
+
+	switch action {
+	case ActionInstall:
+		cmd := fmt.Sprintf(mgr.installCmd, shellescape.Quote(identifier))
+		runTerminal(cmd)
+	case ActionRemove:
+		cmd := fmt.Sprintf(mgr.removeCmd, shellescape.Quote(identifier))
+		runTerminal(cmd)
+	case ActionUpdate:
+		runTerminal(mgr.updateCmd)
+	case ActionInfo:
+		cmd := exec.Command("sh", "-c", fmt.Sprintf(mgr.infoCmd, shellescape.Quote(identifier)))
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			slog.Error(Name, "info", err, "out", string(out))
+		} else {
+			escaped := strings.ReplaceAll(string(out), "'", "'\\''")
+			runTerminal(fmt.Sprintf("echo '%s'; read -p 'Press Enter...'", escaped))
+		}
+	default:
+		slog.Error(Name, "activate", fmt.Sprintf("unknown action: %s", action))
+	}
+}
+
+func runTerminal(cmd string) {
+	toRun := strings.TrimSpace(fmt.Sprintf("%s %s", common.LaunchPrefix(), common.WrapWithTerminal(cmd)))
+	c := exec.Command("sh", "-c", toRun)
+	c.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	err := c.Start()
+	if err != nil {
+		slog.Error(Name, "runTerminal", err)
+	} else {
+		go func() { c.Wait() }()
+	}
+}
+
+func Icon() string {
+	return config.Icon
+}
+
+func HideFromProviderlist() bool {
+	return config.HideFromProviderlist
+}
+
+func State(_ string) *pb.ProviderStateResponse {
+	return &pb.ProviderStateResponse{}
+}

--- a/internal/providers/systempower/README.md
+++ b/internal/providers/systempower/README.md
@@ -1,0 +1,22 @@
+### Elephant System Power
+
+Provides system power actions: lock, logout, suspend, hibernate, reboot, and shutdown.
+
+#### Features
+
+- WM-aware lock/logout: auto-detects hyprlock/swaylock/hyprctl/swaymsg, falls back to loginctl
+- Hibernate detection: only shows hibernate option when swap supports it
+- Configurable lock/logout commands with auto-detection
+- No external dependencies beyond systemd
+
+#### Requirements
+
+- `systemctl` (systemd)
+
+#### Configuration
+
+- `lock_cmd` — override lock command (default: auto-detected)
+- `logout_cmd` — override logout command (default: auto-detected)
+- `auto_detect_lock` — auto-detect lock command (default: `true`)
+- `auto_detect_logout` — auto-detect logout command (default: `true`)
+- `icon` — icon name (default: `system-shutdown`)

--- a/internal/providers/systempower/makefile
+++ b/internal/providers/systempower/makefile
@@ -1,0 +1,36 @@
+DESTDIR ?=
+CONFIGDIR = $(DESTDIR)/etc/xdg/elephant/providers
+
+GO_BUILD_FLAGS = -buildvcs=false -buildmode=plugin -trimpath
+PLUGIN_NAME = systempower.so
+
+.PHONY: all build install uninstall clean
+
+all: build
+
+build:
+	go build $(GO_BUILD_FLAGS)
+
+install: build
+	install -Dm 755 $(PLUGIN_NAME) $(CONFIGDIR)/$(PLUGIN_NAME)
+
+uninstall:
+	rm -f $(CONFIGDIR)/$(PLUGIN_NAME)
+
+clean:
+	go clean
+	rm -f $(PLUGIN_NAME)
+
+dev-install: install
+
+help:
+	@echo "Available targets:"
+	@echo "  all       - Build the plugin (default)"
+	@echo "  build     - Build the plugin"
+	@echo "  install   - Install the plugin"
+	@echo "  uninstall - Remove installed plugin"
+	@echo "  clean     - Clean build artifacts"
+	@echo "  help      - Show this help"
+	@echo ""
+	@echo "Variables:"
+	@echo "  DESTDIR   - Destination directory for staged installs"

--- a/internal/providers/systempower/setup.go
+++ b/internal/providers/systempower/setup.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	_ "embed"
+
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
+)
+
+var (
+	Name       = "systempower"
+	NamePretty = "System Power"
+	config     *Config
+)
+
+//go:embed README.md
+var readme string
+
+const (
+	ActionLock      = "lock"
+	ActionLogout    = "logout"
+	ActionSuspend   = "suspend"
+	ActionHibernate = "hibernate"
+	ActionReboot    = "reboot"
+	ActionShutdown  = "shutdown"
+)
+
+type Config struct {
+	common.Config    `koanf:",squash"`
+	LockCmd          string `koanf:"lock_cmd" desc:"command to lock the screen (auto-detected if empty)" default:""`
+	LogoutCmd        string `koanf:"logout_cmd" desc:"command to logout (auto-detected if empty)" default:""`
+	AutoDetectLock   bool   `koanf:"auto_detect_lock" desc:"auto-detect lock command (hyprlock, swaylock, loginctl)" default:"true"`
+	AutoDetectLogout bool   `koanf:"auto_detect_logout" desc:"auto-detect logout command (hyprctl, swaymsg, loginctl)" default:"true"`
+}
+
+func detectLockCmd() string {
+	for _, bin := range []string{"hyprlock", "swaylock", "loginctl"} {
+		if _, err := exec.LookPath(bin); err == nil {
+			switch bin {
+			case "hyprlock":
+				if os.Getenv("HYPRLAND_INSTANCE_SIGNATURE") != "" {
+					return "hyprlock"
+				}
+			case "swaylock":
+				if os.Getenv("SWAYSOCK") != "" {
+					return "swaylock"
+				}
+			default:
+				return "loginctl lock-session"
+			}
+		}
+	}
+	return "loginctl lock-session"
+}
+
+func detectLogoutCmd() string {
+	if hyprctl, _ := exec.LookPath("hyprctl"); hyprctl != "" {
+		if os.Getenv("HYPRLAND_INSTANCE_SIGNATURE") != "" {
+			return "hyprctl dispatch exit"
+		}
+	}
+	if swaymsg, _ := exec.LookPath("swaymsg"); swaymsg != "" {
+		if os.Getenv("SWAYSOCK") != "" {
+			return "swaymsg exit"
+		}
+	}
+	return "loginctl terminate-session"
+}
+
+func Setup() {
+	LoadConfig()
+
+	if config.NamePretty != "" {
+		NamePretty = config.NamePretty
+	}
+}
+
+func LoadConfig() {
+	config = &Config{
+		Config: common.Config{
+			Icon: "system-shutdown",
+		},
+		LockCmd:          "",
+		LogoutCmd:        "",
+		AutoDetectLock:   true,
+		AutoDetectLogout: true,
+	}
+
+	common.LoadConfig(Name, config)
+
+	if config.AutoDetectLock && config.LockCmd == "" {
+		config.LockCmd = detectLockCmd()
+	}
+	if config.AutoDetectLogout && config.LogoutCmd == "" {
+		config.LogoutCmd = detectLogoutCmd()
+	}
+}
+
+func Available() bool {
+	_, err := exec.LookPath("systemctl")
+	return err == nil
+}
+
+func PrintDoc(write bool) {
+	if !write {
+		fmt.Println(readme)
+		fmt.Println()
+	}
+
+	util.PrintConfig(config, Name, write)
+}
+
+var actions = []struct {
+	Name    string
+	Action  string
+	Icon    string
+	Subtext string
+}{
+	{Name: "Lock", Action: ActionLock, Icon: "system-lock-screen", Subtext: "Lock screen now"},
+	{Name: "Logout", Action: ActionLogout, Icon: "system-log-out", Subtext: "Log out of session"},
+	{Name: "Suspend", Action: ActionSuspend, Icon: "system-suspend", Subtext: "Suspend to RAM"},
+	{Name: "Hibernate", Action: ActionHibernate, Icon: "system-hibernate", Subtext: "Suspend to disk"},
+	{Name: "Reboot", Action: ActionReboot, Icon: "system-reboot", Subtext: "Restart system"},
+	{Name: "Shutdown", Action: ActionShutdown, Icon: "system-shutdown", Subtext: "Power off system"},
+}
+
+func Query(conn net.Conn, query string, _ bool, _ bool, _ uint8) []*pb.QueryResponse_Item {
+	entries := []*pb.QueryResponse_Item{}
+
+	for i, a := range actions {
+		hasHibernate := a.Action == ActionHibernate
+
+		if hasHibernate && !hibernationSupported() {
+			continue
+		}
+
+		e := &pb.QueryResponse_Item{
+			Identifier: a.Action,
+			Text:       a.Name,
+			Subtext:    a.Subtext,
+			Icon:       a.Icon,
+			Provider:   Name,
+			Score:      int32(len(actions) - i + 100),
+			Type:       pb.QueryResponse_REGULAR,
+			Actions:    []string{a.Action},
+		}
+
+		if query != "" {
+			score, _, _ := common.FuzzyScore(query, a.Name, false)
+			e.Score = score
+
+			if e.Score > config.MinScore {
+				entries = append(entries, e)
+			}
+		} else {
+			entries = append(entries, e)
+		}
+	}
+
+	return entries
+}
+
+func Activate(_ bool, identifier, action string, _ string, _ string, _ uint8, _ net.Conn) {
+	_ = identifier
+
+	switch action {
+	case ActionLock:
+		runCmd(config.LockCmd, "Locking...")
+	case ActionLogout:
+		runCmd(config.LogoutCmd, "Logging out...")
+	case ActionSuspend:
+		runCmd("systemctl suspend", "Suspending...")
+	case ActionHibernate:
+		if hibernationSupported() {
+			runCmd("systemctl hibernate", "Hibernating...")
+		} else {
+			slog.Error(Name, "hibernate", "not supported")
+		}
+	case ActionReboot:
+		runCmd("systemctl reboot", "Rebooting...")
+	case ActionShutdown:
+		runCmd("systemctl poweroff", "Shutting down...")
+	default:
+		slog.Error(Name, "activate", fmt.Sprintf("unknown action: %s", action))
+	}
+}
+
+func runCmd(cmd, msg string) {
+	if msg != "" {
+		slog.Info(Name, "action", msg)
+	}
+	c := exec.Command("sh", "-c", cmd)
+	c.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	err := c.Start()
+	if err != nil {
+		slog.Error(Name, "runCmd", err)
+	} else {
+		go func() { c.Wait() }()
+	}
+}
+
+func hibernationSupported() bool {
+	data, err := os.ReadFile("/sys/power/image_size")
+	if err != nil {
+		return false
+	}
+	imageSize := strings.TrimSpace(string(data))
+	if imageSize == "0" {
+		return false
+	}
+
+	swapData, err := os.ReadFile("/proc/swaps")
+	if err != nil {
+		return false
+	}
+	lines := strings.Split(string(swapData), "\n")
+	for i, line := range lines {
+		if i == 0 || strings.TrimSpace(line) == "" {
+			continue
+		}
+		if strings.Contains(line, "zram") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[2] != "0" {
+			return true
+		}
+	}
+	return false
+}
+
+func Icon() string {
+	return config.Icon
+}
+
+func HideFromProviderlist() bool {
+	return config.HideFromProviderlist
+}
+
+func State(_ string) *pb.ProviderStateResponse {
+	return &pb.ProviderStateResponse{}
+}


### PR DESCRIPTION
## Summary

Two new cross-distro, cross-WM providers:

### `systempower`
- Lock, Logout, Suspend, Hibernate, Reboot, Shutdown
- WM-aware lock/logout auto-detection: hyprlock → swaylock → loginctl (lock), hyprctl → swaymsg → loginctl (logout)
- Hibernate only shown when swap supports it (`/sys/power/image_size` + `/proc/swaps`, excludes zram)

### `systempackage`
- Cross-distro package management supporting pacman, apt, dnf, zypper, apk
- Fuzzy package search, Install/Remove/Info actions
- "Update System Packages" shown on empty query
- Uses `common.WrapWithTerminal()` for terminal detection and `common.LaunchPrefix()` for uwsm/systemd-run
- Package names shell-escaped via `shellescape.Quote()`

## Design decisions

- Both providers follow existing patterns from `dnfpackages` and `archlinuxpkgs` (single `setup.go`, `common.Config` embedding, `common.WrapWithTerminal()`)
- `systempackage` fills the gap for non-Arch/non-Fedora distros — works alongside the existing `archlinuxpkgs` and `dnfpackages` providers
- `systempower` complements the WM-specific providers (niriactions, nirisessions) for universal power actions
- Auto-detection defaults can be overridden via per-provider TOML config

## CI

Added build + archive steps for both plugins in `build.yml`.

## Tested

- `go fmt` + `go vet` pass
- Both compile to `.so` plugins successfully
- Loaded via `ELEPHANT_DEV=true` with custom-built elephant binary
- `systempower` returns 5 actions (Hibernate correctly hidden on non-swap machines)
- `systempackage` returns search results from `dnf search` on Fedora