### PR TITLE
perf(files): persistent read conn, prepared stmts, xxhash identifiers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/air-verse/air v1.63.4 // indirect
 	github.com/bep/godartsass/v2 v2.5.0 // indirect
 	github.com/bep/golibsass v1.2.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect

--- a/internal/providers/files/db.go
+++ b/internal/providers/files/db.go
@@ -12,7 +12,15 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-var db *sql.DB
+var (
+	db          *sql.DB
+	readDB      *sql.DB
+	putFileStmt *sql.Stmt
+	getFileStmt *sql.Stmt
+	delFileStmt *sql.Stmt
+)
+
+const dbPragmas = "_journal_mode=WAL&_synchronous=NORMAL&_cache_size=10000&_temp_store=memory&_busy_timeout=5000"
 
 func openDB() error {
 	path := common.CacheFile("files.db")
@@ -33,7 +41,9 @@ func openDB() error {
 		time.Sleep(time.Millisecond * 10)
 	}
 
-	db, err = sql.Open("sqlite3", path+"?_journal_mode=WAL&_synchronous=NORMAL&_cache_size=10000&_temp_store=memory&_busy_timeout=5000")
+	dsn := path + "?" + dbPragmas
+
+	db, err = sql.Open("sqlite3", dsn)
 	if err != nil {
 		return fmt.Errorf("sql open: %v", err)
 	}
@@ -61,6 +71,28 @@ func openDB() error {
 		return fmt.Errorf("sql create index changed: %v", err)
 	}
 
+	putFileStmt, err = db.Prepare("INSERT OR REPLACE INTO files (identifier, path, changed) VALUES (?, ?, ?)")
+	if err != nil {
+		return fmt.Errorf("prepare put: %v", err)
+	}
+
+	getFileStmt, err = db.Prepare("SELECT identifier, path, changed FROM files WHERE identifier = ?")
+	if err != nil {
+		return fmt.Errorf("prepare get: %v", err)
+	}
+
+	delFileStmt, err = db.Prepare("DELETE FROM files WHERE path LIKE ?")
+	if err != nil {
+		return fmt.Errorf("prepare delete: %v", err)
+	}
+
+	readDB, err = sql.Open("sqlite3", dsn)
+	if err != nil {
+		return fmt.Errorf("sql open read: %v", err)
+	}
+
+	readDB.SetMaxOpenConns(1)
+
 	return nil
 }
 
@@ -71,10 +103,7 @@ func putFileBatch(files []File) error {
 	}
 	defer tx.Rollback()
 
-	stmt, err := tx.Prepare("INSERT OR REPLACE INTO files (identifier, path, changed) VALUES (?, ?, ?)")
-	if err != nil {
-		return err
-	}
+	stmt := tx.Stmt(putFileStmt)
 	defer stmt.Close()
 
 	for _, f := range files {
@@ -104,8 +133,7 @@ func putFile(f File) {
 		changedUnix = f.Changed.Unix()
 	}
 
-	_, err := db.Exec("INSERT OR REPLACE INTO files (identifier, path, changed) VALUES (?, ?, ?)",
-		f.Identifier, f.Path, changedUnix)
+	_, err := putFileStmt.Exec(f.Identifier, f.Path, changedUnix)
 	if err != nil {
 		slog.Error(Name, "put", err)
 	}
@@ -115,8 +143,7 @@ func getFile(identifier string) *File {
 	var f File
 	var changedUnix int64
 
-	err := db.QueryRow("SELECT identifier, path, changed FROM files WHERE identifier = ?", identifier).
-		Scan(&f.Identifier, &f.Path, &changedUnix)
+	err := getFileStmt.QueryRow(identifier).Scan(&f.Identifier, &f.Path, &changedUnix)
 	if err != nil {
 		return nil
 	}
@@ -131,21 +158,14 @@ func getFile(identifier string) *File {
 func getFilesByQuery(query string, _ bool) []File {
 	var result []File
 
-	path := common.CacheFile("files.db")
-	queryDB, err := sql.Open("sqlite3", path+"?_journal_mode=WAL&_synchronous=NORMAL&_cache_size=10000&_temp_store=memory&_busy_timeout=5000")
-	if err != nil {
-		slog.Error(Name, "open query db", err)
-		return nil
-	}
-	defer queryDB.Close()
-
 	var rows *sql.Rows
+	var err error
 
 	if query != "" {
 		likePattern := "%" + query + "%"
-		rows, err = queryDB.Query("SELECT identifier, path, changed FROM files WHERE path LIKE ? ORDER BY changed DESC LIMIT 1000", likePattern)
+		rows, err = readDB.Query("SELECT identifier, path, changed FROM files WHERE path LIKE ? ORDER BY changed DESC LIMIT 1000", likePattern)
 	} else {
-		rows, err = queryDB.Query("SELECT identifier, path, changed FROM files WHERE path NOT LIKE '%/' ORDER BY changed DESC LIMIT 100")
+		rows, err = readDB.Query("SELECT identifier, path, changed FROM files WHERE path NOT LIKE '%/' ORDER BY changed DESC LIMIT 100")
 	}
 
 	if err != nil {
@@ -173,7 +193,7 @@ func getFilesByQuery(query string, _ bool) []File {
 }
 
 func deleteFileByPath(path string) {
-	_, err := db.Exec("DELETE FROM files WHERE path LIKE ?", path+"%")
+	_, err := delFileStmt.Exec(path + "%")
 	if err != nil {
 		slog.Error(Name, "delete", err)
 	}

--- a/internal/providers/files/files_test.go
+++ b/internal/providers/files/files_test.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"crypto/md5"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const benchDir = "/home/user/docs"
+
+func benchPaths(n int) []string {
+	paths := make([]string, n)
+	for i := range n {
+		switch {
+		case i%5 == 0:
+			paths[i] = fmt.Sprintf("%s/document_%d.pdf", benchDir, i)
+		case i%5 == 1:
+			paths[i] = fmt.Sprintf("%s/image_%d.png", benchDir, i)
+		case i%5 == 2:
+			paths[i] = fmt.Sprintf("%s/notes_%d.txt", benchDir, i)
+		case i%5 == 3:
+			paths[i] = fmt.Sprintf("%s/downloads/file_%d.zip", benchDir, i)
+		default:
+			paths[i] = fmt.Sprintf("%s/projects/src/main_%d.go", benchDir, i)
+		}
+	}
+	return paths
+}
+
+func setupBenchDB(b *testing.B, n int) (string, *sql.DB) {
+	b.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "files-bench-*")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	path := tmpDir + "/files.db"
+	dsn := path + "?" + dbPragmas
+
+	database, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	_, err = database.Exec(`CREATE TABLE files (
+		identifier TEXT PRIMARY KEY,
+		path TEXT NOT NULL,
+		changed INTEGER
+	)`)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	_, err = database.Exec(`CREATE INDEX idx_files_path ON files(path)`)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	_, err = database.Exec(`CREATE INDEX idx_files_changed ON files(changed DESC)`)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	paths := benchPaths(n)
+	tx, _ := database.Begin()
+	stmt, _ := tx.Prepare("INSERT INTO files (identifier, path, changed) VALUES (?, ?, ?)")
+
+	now := time.Now()
+	for i, p := range paths {
+		id := fmt.Sprintf("%x", i)
+		changed := now.Add(-time.Duration(i) * time.Minute).Unix()
+		stmt.Exec(id, p, changed)
+	}
+
+	stmt.Close()
+	tx.Commit()
+
+	return tmpDir, database
+}
+
+func BenchmarkBrowseQuery(b *testing.B) {
+	sizes := []int{1000, 10000, 100000}
+
+	b.Run("newconn", func(b *testing.B) {
+		for _, size := range sizes {
+			b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+				tmpDir, database := setupBenchDB(b, size)
+				dsn := tmpDir + "/files.db?" + dbPragmas
+				database.Close()
+
+				b.ResetTimer()
+				for range b.N {
+					rd, _ := sql.Open("sqlite3", dsn)
+					rows, _ := rd.Query("SELECT identifier, path, changed FROM files WHERE path NOT LIKE '%/' ORDER BY changed DESC LIMIT 100")
+					if rows != nil {
+						for rows.Next() {
+							var id, path string
+							var changed int64
+							rows.Scan(&id, &path, &changed)
+						}
+						rows.Close()
+					}
+					rd.Close()
+				}
+				os.RemoveAll(tmpDir)
+			})
+		}
+	})
+
+	b.Run("persistent", func(b *testing.B) {
+		for _, size := range sizes {
+			b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+				tmpDir, database := setupBenchDB(b, size)
+				dsn := tmpDir + "/files.db?" + dbPragmas
+
+				rd, _ := sql.Open("sqlite3", dsn)
+				defer rd.Close()
+				database.Close()
+
+				b.ResetTimer()
+				for range b.N {
+					rows, _ := rd.Query("SELECT identifier, path, changed FROM files WHERE path NOT LIKE '%/' ORDER BY changed DESC LIMIT 100")
+					if rows != nil {
+						for rows.Next() {
+							var id, path string
+							var changed int64
+							rows.Scan(&id, &path, &changed)
+						}
+						rows.Close()
+					}
+				}
+				os.RemoveAll(tmpDir)
+			})
+		}
+	})
+}
+
+func BenchmarkSearchQuery(b *testing.B) {
+	sizes := []int{1000, 10000, 100000}
+
+	for _, q := range []string{"document", "main", "nonexistent_xyz"} {
+		b.Run(fmt.Sprintf("query_%s", q), func(b *testing.B) {
+			b.Run("newconn", func(b *testing.B) {
+				for _, size := range sizes {
+					b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+						tmpDir, database := setupBenchDB(b, size)
+						dsn := tmpDir + "/files.db?" + dbPragmas
+						database.Close()
+
+						likePattern := "%" + q + "%"
+
+						b.ResetTimer()
+						for range b.N {
+							rd, _ := sql.Open("sqlite3", dsn)
+							rows, _ := rd.Query("SELECT identifier, path, changed FROM files WHERE path LIKE ? ORDER BY changed DESC LIMIT 1000", likePattern)
+							if rows != nil {
+								for rows.Next() {
+									var id, path string
+									var changed int64
+									rows.Scan(&id, &path, &changed)
+								}
+								rows.Close()
+							}
+							rd.Close()
+						}
+						os.RemoveAll(tmpDir)
+					})
+				}
+			})
+
+			b.Run("persistent", func(b *testing.B) {
+				for _, size := range sizes {
+					b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+						tmpDir, database := setupBenchDB(b, size)
+						dsn := tmpDir + "/files.db?" + dbPragmas
+
+						rd, _ := sql.Open("sqlite3", dsn)
+						defer rd.Close()
+						database.Close()
+
+						likePattern := "%" + q + "%"
+
+						b.ResetTimer()
+						for range b.N {
+							rows, _ := rd.Query("SELECT identifier, path, changed FROM files WHERE path LIKE ? ORDER BY changed DESC LIMIT 1000", likePattern)
+							if rows != nil {
+								for rows.Next() {
+									var id, path string
+									var changed int64
+									rows.Scan(&id, &path, &changed)
+								}
+								rows.Close()
+							}
+						}
+						os.RemoveAll(tmpDir)
+					})
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkPutFile(b *testing.B) {
+	tmpDir, database := setupBenchDB(b, 1000)
+	dsn := tmpDir + "/files.db?" + dbPragmas
+	database.Close()
+
+	database, _ = sql.Open("sqlite3", dsn)
+	defer database.Close()
+
+	stmt, _ := database.Prepare("INSERT OR REPLACE INTO files (identifier, path, changed) VALUES (?, ?, ?)")
+	defer stmt.Close()
+
+	b.ResetTimer()
+
+	for range b.N {
+		id := fmt.Sprintf("new_%d", b.N)
+		stmt.Exec(id, "/home/user/new_file.txt", time.Now().Unix())
+	}
+	os.RemoveAll(tmpDir)
+}
+
+func BenchmarkInsertBatch(b *testing.B) {
+	tmpDir, database := setupBenchDB(b, 1000)
+	dsn := tmpDir + "/files.db?" + dbPragmas
+	database.Close()
+
+	b.ResetTimer()
+
+	for range b.N {
+		database, _ = sql.Open("sqlite3", dsn)
+		paths := benchPaths(5000)
+		tx, _ := database.Begin()
+		stmt, _ := tx.Prepare("INSERT OR REPLACE INTO files (identifier, path, changed) VALUES (?, ?, ?)")
+		for i, p := range paths {
+			stmt.Exec(fmt.Sprintf("batch_%d_%d", b.N, i), p, time.Now().Unix())
+		}
+		stmt.Close()
+		tx.Commit()
+		database.Close()
+	}
+
+	os.RemoveAll(tmpDir)
+}
+
+func BenchmarkHash(b *testing.B) {
+	paths := benchPaths(1000)
+
+	b.Run("md5", func(b *testing.B) {
+		for range b.N {
+			for _, p := range paths {
+				h := md5.Sum([]byte(p))
+				_ = fmt.Sprintf("%x", h)
+			}
+		}
+	})
+
+	b.Run("xxhash", func(b *testing.B) {
+		for range b.N {
+			for _, p := range paths {
+				_ = fmt.Sprintf("%x", xxhash.Sum64String(p))
+			}
+		}
+	})
+}

--- a/internal/providers/files/setup.go
+++ b/internal/providers/files/setup.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"bufio"
-	"crypto/md5"
 	_ "embed"
-	"encoding/hex"
 	"fmt"
 	"log"
 	"log/slog"
@@ -18,6 +16,7 @@ import (
 	"github.com/abenz1267/elephant/v2/internal/util"
 	"github.com/abenz1267/elephant/v2/pkg/common"
 	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
+	"github.com/cespare/xxhash/v2"
 	"github.com/djherbis/times"
 	"github.com/fsnotify/fsnotify"
 )
@@ -167,11 +166,10 @@ func index() {
 		if info, err := times.Stat(path); err == nil {
 			diff := start.Sub(info.ChangeTime())
 
-			md5 := md5.Sum([]byte(path))
-			md5str := hex.EncodeToString(md5[:])
+			id := fmt.Sprintf("%x", xxhash.Sum64String(path))
 
 			f := File{
-				Identifier: md5str,
+				Identifier: id,
 				Path:       path,
 				Changed:    time.Time{},
 			}
@@ -209,11 +207,10 @@ outer:
 			if info, err := times.Stat(path); err == nil {
 				diff := start.Sub(info.ChangeTime())
 
-				md5 := md5.Sum([]byte(path))
-				md5str := hex.EncodeToString(md5[:])
+				id := fmt.Sprintf("%x", xxhash.Sum64String(path))
 
 				f := File{
-					Identifier: md5str,
+					Identifier: id,
 					Path:       path,
 					Changed:    time.Time{},
 				}
@@ -308,15 +305,14 @@ func handleRegular(regularChan chan string) {
 								}
 							}
 
-							md5 := md5.Sum([]byte(path))
-							md5str := hex.EncodeToString(md5[:])
+							id := fmt.Sprintf("%x", xxhash.Sum64String(path))
 
-							if val := getFile(md5str); val != nil {
+							if val := getFile(id); val != nil {
 								val.Changed = info.ChangeTime()
 								putFile(*val)
 							} else {
 								putFile(File{
-									Identifier: md5str,
+									Identifier: id,
 									Path:       path,
 									Changed:    info.ChangeTime(),
 								})


### PR DESCRIPTION
Was looking at the files provider after seeing douglas' clipboard PR (#244) — the patterns applied there made sense for files too.

**Changes:**

1. **Persistent read-only DB connection** — getFilesByQuery was opening/closing a fresh sqlite connection on every keystroke. Extracted a readDB connection initialized once at startup, same as the clipboard PR did.

2. **Prepared statements** — putFile, getFile, deleteFileByPath now use prepared statements initialized in openDB(). putFileBatch reuses the global stmt via tx.Stmt().

3. **xxhash identifiers** — replaced crypto/md5 + encoding/hex with xxhash.Sum64String for file path hashing. ~3x faster in benchmarks.

4. **dbPragmas const** — extracted the shared connection string to avoid duplication between read and write connections.

**Benchmarks:**

All on Celeron N5100 @ 1.10GHz.

| Benchmark | newconn (old) | persistent (new) | improvement |
|---|---|---|---|
| Browse (100k) | 513µs | 207µs | **~55%** |
| Search "document" (100k) | 3.19ms | 2.59ms | **~19%** |
| Search "nonexistent" (100k) | 23.1ms | 18.6ms | **~19%** |
| MD5 (1000 paths) | 521µs | xxhash 165µs | **~3.2x** |

Numbers 1-3 are self-contained and there's more that could be done (parallel indexing, FTS5 instead of LIKE, not destroying the DB on restart) but those would be follow-up PRs.
