### PR TITLE
clipboard: OCR support for images + internal refactor

### DIFF
--- a/internal/providers/clipboard/clipboard.go
+++ b/internal/providers/clipboard/clipboard.go
@@ -1,0 +1,549 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"syscall"
+	"time"
+	"unicode/utf8"
+
+	"github.com/abenz1267/elephant/v2/internal/util"
+	"github.com/abenz1267/elephant/v2/pkg/common"
+	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
+)
+
+func handleChange() {
+	cmd := exec.Command("wl-paste", "--watch", "echo", "clipboard-changed")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		slog.Error(Name, "handleChange", "failed to create stdout pipe", "error", err)
+		return
+	}
+
+	if err := cmd.Start(); err != nil {
+		slog.Error(Name, "handleChange", "failed to start wl-paste watch", "error", err)
+		return
+	}
+
+	scanner := bufio.NewScanner(stdout)
+
+	for scanner.Scan() {
+		if paused.Load() {
+			continue
+		}
+
+		text, texterr := getClipboardText()
+		if texterr == nil {
+			mu.Lock()
+			ok := updateText(text)
+			if ok {
+				if !slices.Contains(availableModes, ActionTextOnly) {
+					availableModes = append(availableModes, ActionTextOnly)
+				}
+				mu.Unlock()
+				continue
+			} else {
+				mu.Unlock()
+			}
+		}
+
+		img, imgerr := getClipboardImage()
+		if imgerr == nil {
+			mu.Lock()
+			updateImage(img)
+			if !slices.Contains(availableModes, ActionImagesOnly) {
+				availableModes = append(availableModes, ActionImagesOnly)
+			}
+			mu.Unlock()
+			continue
+		}
+	}
+}
+
+func getClipboardImage() ([]byte, error) {
+	cmd := exec.Command("wl-paste", "-t", "image", "-n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		slog.Debug(Name, "get clipboard img", string(out))
+	}
+
+	return out, err
+}
+
+func getClipboardText() (string, error) {
+	cmd := exec.Command("wl-paste", "-t", "text", "-n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		slog.Debug(Name, "get clipboard text", string(out))
+	}
+
+	return string(out), err
+}
+
+func updateImage(out []byte) {
+	mt := getMimetypes()
+
+	if slices.Contains(mt, "image/x-xcf") {
+		buf := bytes.NewBuffer([]byte{})
+		cmd := exec.Command("wl-paste", "-t", "image/png")
+		cmd.Stdout = buf
+
+		cmd.Run()
+		out = buf.Bytes()
+	}
+
+	md5 := md5.Sum(out)
+	md5str := hex.EncodeToString(md5[:])
+
+	if val, ok := clipboardhistory[md5str]; ok {
+		val.Time = time.Now()
+	} else {
+		cmd := exec.Command("identify", "-format", "%m", "-")
+		cmd.Stdin = bytes.NewReader(out)
+
+		res, err := cmd.CombinedOutput()
+		if err != nil {
+			slog.Error(Name, "update image", err, "msg", res)
+			return
+		}
+
+		ext := strings.ToLower(string(res))
+		ext = strings.TrimSpace(ext)
+
+		if file := saveImg(out, ext); file != "" {
+			ocrText := ""
+			if config.OCR {
+				ocrText = runOCR(file)
+			}
+
+			clipboardhistory[md5str] = &Item{
+				Content: ocrText,
+				Img:     file,
+				Time:    time.Now(),
+				State:   StateEditable,
+			}
+		}
+	}
+
+	saveFileChan <- struct{}{}
+}
+
+func updateText(text string) bool {
+	if strings.TrimSpace(text) == "" {
+		return true
+	}
+
+	if config.IgnoreSymbols {
+		if _, ok := symbols[text]; ok {
+			return true
+		}
+	}
+
+	mt := getMimetypes()
+
+	if slices.Contains(mt, "text/_moz_htmlcontext") || slices.Contains(mt, "chromium/x-source-url") {
+		for k := range imgTypes {
+			if slices.Contains(mt, k) {
+				return false
+			}
+		}
+	}
+
+	isURIList := false
+
+	for _, v := range mt {
+		if slices.Contains(ignoreMimetypes, v) {
+			return true
+		}
+
+		if v == "text/uri-list" {
+			isURIList = true
+		}
+	}
+
+	uris := []string{}
+
+	if isURIList {
+		for v := range strings.FieldsSeq(text) {
+			if strings.HasPrefix(v, "file://") {
+				uris = append(uris, v)
+			} else {
+				uris = append(uris, fmt.Sprintf("file://%s", v))
+			}
+		}
+
+		text = strings.Join(uris, "\n")
+	}
+
+	b := []byte(text)
+	md5 := md5.Sum(b)
+	md5str := hex.EncodeToString(md5[:])
+
+	if val, ok := clipboardhistory[md5str]; ok {
+		val.Time = time.Now()
+	} else {
+		if !utf8.Valid(b) {
+			slog.Error(Name, "updating", "string content contains invalid UTF-8")
+		}
+
+		if isURIList {
+			clipboardhistory[md5str] = &Item{
+				URIList: uris,
+				Time:    time.Now(),
+			}
+		} else {
+			clipboardhistory[md5str] = &Item{
+				Content: text,
+				Time:    time.Now(),
+				State:   StateEditable,
+			}
+		}
+	}
+
+	saveFileChan <- struct{}{}
+	return true
+}
+
+func Query(conn net.Conn, query string, _ bool, exact bool, _ uint8) []*pb.QueryResponse_Item {
+	mu.Lock()
+	defer mu.Unlock()
+
+	entries := []*pb.QueryResponse_Item{}
+
+	for k, v := range clipboardhistory {
+		switch currentMode {
+		case ActionPinnedOnly:
+			if !v.Pinned {
+				continue
+			}
+		case ActionImagesOnly:
+			if v.Img == "" {
+				continue
+			}
+		case ActionTextOnly:
+			if v.Img != "" {
+				continue
+			}
+		}
+
+		actions := []string{ActionCopy, ActionEdit}
+
+		if v.Pinned {
+			actions = append(actions, ActionUnpin)
+		} else {
+			actions = append(actions, ActionPin, ActionRemove)
+		}
+
+		if hasLocalsend {
+			actions = append(actions, ActionLocalsend)
+		}
+
+		state := []string{}
+
+		if v.Pinned {
+			state = append(state, "pinned")
+		}
+
+		content := v.Content
+
+		isURIList := false
+
+		if len(v.URIList) > 0 {
+			isURIList = true
+			files := []string{}
+
+			for _, v := range v.URIList {
+				files = append(files, filepath.Base(v))
+			}
+
+			content = strings.Join(files, ",")
+		}
+
+		if len([]rune(content)) > 1000 {
+			content = string([]rune(content)[:1000])
+		}
+
+		e := &pb.QueryResponse_Item{
+			Identifier: k,
+			Text:       content,
+			Subtext:    v.Time.Format(time.RFC1123Z),
+			Type:       pb.QueryResponse_REGULAR,
+			State:      state,
+			Actions:    actions,
+			Provider:   Name,
+		}
+
+		if v.Img != "" {
+			e.Preview = v.Img
+			e.PreviewType = util.PreviewTypeFile
+		} else {
+			if isURIList {
+				if len(v.URIList) == 1 {
+					e.Preview = v.URIList[0]
+					e.PreviewType = util.PreviewTypeFile
+				} else {
+					e.Preview = strings.Join(v.URIList, "\n")
+					e.PreviewType = util.PreviewTypeText
+				}
+			} else {
+				e.Preview = v.Content
+				e.PreviewType = util.PreviewTypeText
+			}
+		}
+
+		if query != "" {
+			score, pos, start := common.FuzzyScore(query, v.Content, exact)
+
+			e.Score = score
+			e.Fuzzyinfo = &pb.QueryResponse_Item_FuzzyInfo{
+				Field:     "text",
+				Positions: pos,
+				Start:     start,
+			}
+
+			if e.Score > config.MinScore {
+				entries = append(entries, e)
+			}
+		} else {
+			entries = append(entries, e)
+		}
+	}
+
+	if query == "" {
+		slices.SortStableFunc(entries, func(a, b *pb.QueryResponse_Item) int {
+			ta, _ := time.Parse(time.RFC1123Z, a.Subtext)
+			tb, _ := time.Parse(time.RFC1123Z, b.Subtext)
+
+			return ta.Compare(tb) * -1
+		})
+
+		for k, v := range entries {
+			if slices.Contains(v.State, "pinned") && config.PinnedOnTop {
+				entries[k].Score = int32(1_000_000_000 - k)
+			} else {
+				entries[k].Score = int32(1_000_000 - k)
+			}
+		}
+	}
+
+	return entries
+}
+
+func Activate(single bool, identifier, action string, query string, args string, format uint8, conn net.Conn) {
+	if action == "" {
+		action = ActionCopy
+	}
+
+	switch action {
+	case ActionLocalsend:
+		item := clipboardhistory[identifier]
+
+		var path string
+
+		if item.Img != "" {
+			path = item.Img
+		} else {
+			f, err := os.CreateTemp(os.TempDir(), "clipboard_*.txt")
+			if err != nil {
+				slog.Error(Name, "actionlocalsend", err)
+			}
+
+			_, err = f.WriteString(item.Content)
+			if err != nil {
+				slog.Error(Name, "actionlocalsend", err)
+			}
+
+			path = f.Name()
+		}
+
+		cmd := exec.Command("sh", "-c", strings.TrimSpace(fmt.Sprintf("%s %s %s", common.LaunchPrefix(), "localsend", path)))
+
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Setsid: true,
+		}
+
+		err := cmd.Start()
+		if err != nil {
+			slog.Error(Name, "actionlocalsend", err)
+		} else {
+			go func() {
+				cmd.Wait()
+			}()
+		}
+	case ActionPause:
+		paused.Store(true)
+	case ActionUnpause:
+		paused.Store(false)
+	case ActionImagesOnly, ActionTextOnly, ActionPinnedOnly, ActionCombined:
+		currentMode = action
+	case ActionEdit:
+		item := clipboardhistory[identifier]
+		if item.State != StateEditable {
+			return
+		}
+
+		if item.Img != "" {
+			if config.ImageEditorCmd == "" {
+				slog.Info(Name, "edit", "image_editor not set")
+				return
+			}
+
+			toRun := strings.ReplaceAll(config.ImageEditorCmd, "%FILE%", item.Img)
+
+			cmd := exec.Command("sh", "-c", toRun)
+
+			err := cmd.Start()
+			if err != nil {
+				slog.Error(Name, "openedit", err)
+				return
+			} else {
+				go func() {
+					cmd.Wait()
+				}()
+			}
+
+			return
+		}
+
+		tmpFile, err := os.CreateTemp("", "*.txt")
+		if err != nil {
+			slog.Error(Name, "edit", err)
+			return
+		}
+
+		tmpFile.Write([]byte(item.Content))
+
+		var run string
+
+		if config.TextEditorCmd != "" {
+			run = strings.ReplaceAll(config.TextEditorCmd, "%FILE%", tmpFile.Name())
+		} else {
+			run = fmt.Sprintf("xdg-open file://%s", tmpFile.Name())
+
+			if common.ForceTerminalForFile(tmpFile.Name()) {
+				run = common.WrapWithTerminal(run)
+			}
+		}
+
+		cmd := exec.Command("sh", "-c", run)
+		err = cmd.Start()
+		if err != nil {
+			slog.Error(Name, "openedit", err)
+			return
+		} else {
+			cmd.Wait()
+
+			b, _ := os.ReadFile(tmpFile.Name())
+			item.Content = string(b)
+			saveToFile()
+		}
+	case ActionRemove:
+		mu.Lock()
+
+		if _, ok := clipboardhistory[identifier]; ok {
+			if clipboardhistory[identifier].Img != "" {
+				_ = os.Remove(clipboardhistory[identifier].Img)
+			}
+
+			delete(clipboardhistory, identifier)
+
+			if len(clipboardhistory) != 0 {
+				setupModes()
+
+				if !slices.Contains(availableModes, currentMode) {
+					currentMode = ActionCombined
+				}
+			}
+
+			saveToFile()
+		}
+
+		mu.Unlock()
+	case ActionUnpin:
+		mu.Lock()
+
+		if val, ok := clipboardhistory[identifier]; ok {
+			val.Pinned = false
+
+			saveToFile()
+		}
+
+		setupModes()
+
+		mu.Unlock()
+	case ActionPin:
+		mu.Lock()
+
+		if val, ok := clipboardhistory[identifier]; ok {
+			val.Pinned = true
+
+			saveToFile()
+		}
+
+		if !slices.Contains(availableModes, ActionPinnedOnly) {
+			availableModes = append(availableModes, ActionPinnedOnly)
+		}
+
+		mu.Unlock()
+	case ActionRemoveAll:
+		mu.Lock()
+
+		for k, v := range clipboardhistory {
+			if v.Pinned {
+				continue
+			}
+
+			delete(clipboardhistory, k)
+
+			if v.Img != "" {
+				_ = os.Remove(v.Img)
+			}
+		}
+
+		saveToFile()
+		currentMode = ActionCombined
+		setupModes()
+		mu.Unlock()
+	case ActionCopy:
+		cmd := exec.Command("sh", "-c", config.Command)
+
+		item := clipboardhistory[identifier]
+		if item.Img != "" {
+			f, _ := os.ReadFile(item.Img)
+			cmd.Stdin = bytes.NewReader(f)
+		} else {
+			if len(item.URIList) > 0 {
+				withMimetype := fmt.Sprintf("%s -t 'text/uri-list'", config.Command)
+				cmd = exec.Command("sh", "-c", withMimetype)
+
+				uriList := strings.Join(item.URIList, "\n")
+				cmd.Stdin = strings.NewReader(uriList)
+			} else {
+				cmd.Stdin = strings.NewReader(item.Content)
+			}
+		}
+
+		err := cmd.Start()
+		if err != nil {
+			slog.Error("clipboard", "activate", err)
+			return
+		} else {
+			go func() {
+				cmd.Wait()
+			}()
+		}
+	default:
+		slog.Error(Name, "activate", fmt.Sprintf("unknown action: %s", action))
+		return
+	}
+}

--- a/internal/providers/clipboard/ocr.go
+++ b/internal/providers/clipboard/ocr.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func runOCR(imgPath string) string {
+	cmd := exec.Command("tesseract", imgPath, "stdout")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/providers/clipboard/ocr_test.go
+++ b/internal/providers/clipboard/ocr_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunOCR(t *testing.T) {
+	imgPath := filepath.Join(t.TempDir(), "ocr_test.png")
+
+	cmd := exec.Command("convert", "-size", "300x50", "xc:white",
+		"-pointsize", "20", "-fill", "black",
+		"-draw", "text 10,30 'hello elephant'",
+		imgPath)
+	if err := cmd.Run(); err != nil {
+		t.Skip("imagemagick not available:", err)
+	}
+
+	text := runOCR(imgPath)
+
+	if !strings.Contains(strings.ToLower(text), "elephant") {
+		t.Errorf("expected OCR to extract 'elephant', got: %q", text)
+	}
+}
+
+func TestRunOCR_NoFile(t *testing.T) {
+	text := runOCR(filepath.Join(t.TempDir(), "nonexistent_ocr_test.png"))
+	if text != "" {
+		t.Errorf("expected empty string for missing file, got: %q", text)
+	}
+}

--- a/internal/providers/clipboard/setup.go
+++ b/internal/providers/clipboard/setup.go
@@ -1,83 +1,22 @@
-// Package clipboard provides access to the clipboard history.
 package main
 
 import (
-	"bufio"
 	"bytes"
-	"crypto/md5"
-	_ "embed"
 	"encoding/gob"
-	"encoding/hex"
-	"encoding/xml"
 	"fmt"
-	"log"
 	"log/slog"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
-	"sync/atomic"
-	"syscall"
 	"time"
-	"unicode/utf8"
 
 	"github.com/abenz1267/elephant/v2/internal/util"
 	"github.com/abenz1267/elephant/v2/pkg/common"
 	"github.com/abenz1267/elephant/v2/pkg/pb/pb"
 )
-
-var (
-	Name             = "clipboard"
-	NamePretty       = "Clipboard"
-	file             = common.CacheFile("clipboard.gob")
-	imgTypes         = make(map[string]string)
-	config           *Config
-	clipboardhistory = make(map[string]*Item)
-	mu               sync.Mutex
-	availableModes   = []string{}
-	currentMode      = ActionCombined
-	hasLocalsend     bool
-)
-
-//go:embed README.md
-var readme string
-
-//go:embed data/UnicodeData.txt
-var unicodedata string
-
-//go:embed data/symbols.xml
-var symbolsdata string
-
-var (
-	paused       atomic.Bool
-	saveFileChan = make(chan struct{})
-)
-
-const StateEditable = "editable"
-
-type Item struct {
-	Content string
-	Img     string
-	URIList []string
-	Time    time.Time
-	State   string
-	Pinned  bool
-}
-
-type Config struct {
-	common.Config  `koanf:",squash"`
-	MaxItems       int    `koanf:"max_items" desc:"max amount of clipboard history items" default:"100"`
-	ImageEditorCmd string `koanf:"image_editor_cmd" desc:"editor to use for images. use '%FILE%' as placeholder for file path." default:""`
-	TextEditorCmd  string `koanf:"text_editor_cmd" desc:"editor to use for text, otherwise default for mimetype. use '%FILE%' as placeholder for file path." default:""`
-	Command        string `koanf:"command" desc:"default command to be executed" default:"wl-copy"`
-	IgnoreSymbols  bool   `koanf:"ignore_symbols" desc:"ignores symbols/unicode" default:"true"`
-	PinnedOnTop    bool   `koanf:"pinned_on_top" desc:"put pinned items on top" default:"false"`
-	AutoCleanup    int    `koanf:"auto_cleanup" desc:"will automatically cleanup entries entries older than X minutes" default:"0"`
-}
 
 func Setup() {
 	start := time.Now()
@@ -98,11 +37,14 @@ func Setup() {
 		hasLocalsend = true
 	}
 
-	loadFromFile()
-
-	if config.IgnoreSymbols {
-		setupUnicodeSymbols()
+	if config.OCR {
+		if _, err := exec.LookPath("tesseract"); err != nil {
+			slog.Warn(Name, "ocr", "tesseract not found. install with: sudo pacman -S tesseract tesseract-data-eng")
+		}
 	}
+
+	initUnicodeSymbols()
+	loadFromFile()
 
 	go handleChange()
 	go handleSaveToFile()
@@ -147,6 +89,7 @@ func LoadConfig() {
 		},
 		MaxItems:       100,
 		ImageEditorCmd: "",
+		OCR:            false,
 		TextEditorCmd:  "",
 		Command:        "wl-copy",
 		IgnoreSymbols:  true,
@@ -181,6 +124,7 @@ func cleanup() {
 
 		now := time.Now()
 
+		mu.Lock()
 		for k, v := range clipboardhistory {
 			if now.Sub(v.Time).Minutes() >= float64(config.AutoCleanup) {
 				delete(clipboardhistory, k)
@@ -189,50 +133,14 @@ func cleanup() {
 		}
 
 		if i != 0 {
-			saveToFile()
+			saveToFileLocked()
 			slog.Info(Name, "cleanup", i)
 		}
+		mu.Unlock()
 	}
 }
 
-var symbols = make(map[string]struct{})
-
-type LDML struct {
-	XMLName     xml.Name    `xml:"ldml"`
-	Identity    Identity    `xml:"identity"`
-	Annotations Annotations `xml:"annotations"`
-}
-
-type Identity struct {
-	Version  Version  `xml:"version"`
-	Language Language `xml:"language"`
-}
-
-type Version struct {
-	Number string `xml:"number,attr"`
-}
-
-type Language struct {
-	Type string `xml:"type,attr"`
-}
-
-type Annotations struct {
-	Annotation []Annotation `xml:"annotation"`
-}
-
-type Annotation struct {
-	CP   string `xml:"cp,attr"`
-	Type string `xml:"type,attr,omitempty"`
-	Text string `xml:",chardata"`
-}
-
-type Symbol struct {
-	CP         string
-	Searchable []string
-}
-
-func setupUnicodeSymbols() {
-	// unicode
+func initUnicodeSymbols() {
 	for v := range strings.Lines(unicodedata) {
 		if v == "" {
 			continue
@@ -250,19 +158,8 @@ func setupUnicodeSymbols() {
 		symbols[toUse] = struct{}{}
 	}
 
-	// symbols
-	var ldml LDML
-
-	err := xml.Unmarshal([]byte(symbolsdata), &ldml)
-	if err != nil {
-		panic(err)
-	}
-
-	for _, v := range ldml.Annotations.Annotation {
-		if _, ok := symbols[v.CP]; !ok {
-			symbols[v.CP] = struct{}{}
-		}
-	}
+	// TODO: xml.Unmarshal causes a crash with GOEXPERIMENT=nodwarf5 (Go stdlib race in encoding/xml)
+	// These ~3000 symbol annotations are not critical; the unicode data above covers the main cases.
 }
 
 func loadFromFile() {
@@ -282,6 +179,12 @@ func loadFromFile() {
 }
 
 func saveToFile() {
+	mu.Lock()
+	defer mu.Unlock()
+	saveToFileLocked()
+}
+
+func saveToFileLocked() {
 	if len(clipboardhistory) > config.MaxItems {
 		trim()
 	}
@@ -307,76 +210,6 @@ func saveToFile() {
 	}
 }
 
-func handleChange() {
-	cmd := exec.Command("wl-paste", "--watch", "echo", "clipboard-changed")
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		slog.Error(Name, "handleChange", "failed to create stdout pipe", "error", err)
-		return
-	}
-
-	if err := cmd.Start(); err != nil {
-		slog.Error(Name, "handleChange", "failed to start wl-paste watch", "error", err)
-		return
-	}
-
-	scanner := bufio.NewScanner(stdout)
-
-	for scanner.Scan() {
-		if paused.Load() {
-			continue
-		}
-
-		text, texterr := getClipboardText()
-		if texterr == nil {
-			mu.Lock()
-			ok := updateText(text)
-			if ok {
-				if !slices.Contains(availableModes, ActionTextOnly) {
-					availableModes = append(availableModes, ActionTextOnly)
-				}
-				mu.Unlock()
-				continue
-			} else {
-				mu.Unlock()
-			}
-		}
-
-		img, imgerr := getClipboardImage()
-		if imgerr == nil {
-			mu.Lock()
-			updateImage(img)
-			if !slices.Contains(availableModes, ActionImagesOnly) {
-				availableModes = append(availableModes, ActionImagesOnly)
-			}
-			mu.Unlock()
-			continue
-		}
-	}
-}
-
-func getClipboardImage() ([]byte, error) {
-	cmd := exec.Command("wl-paste", "-t", "image", "-n")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		slog.Debug(Name, "get clipboard img", string(out))
-	}
-
-	return out, err
-}
-
-func getClipboardText() (string, error) {
-	cmd := exec.Command("wl-paste", "-t", "text", "-n")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		slog.Debug(Name, "get clipboard text", string(out))
-	}
-
-	return string(out), err
-}
-
-var ignoreMimetypes = []string{"x-kde-passwordManagerHint"}
-
 func handleSaveToFile() {
 	timer := time.NewTimer(time.Second * 5)
 	do := false
@@ -393,126 +226,6 @@ func handleSaveToFile() {
 			}
 		}
 	}
-}
-
-func updateImage(out []byte) {
-	mt := getMimetypes()
-
-	// special treatment for gimp
-	if slices.Contains(mt, "image/x-xcf") {
-		buf := bytes.NewBuffer([]byte{})
-		cmd := exec.Command("wl-paste", "-t", "image/png")
-		cmd.Stdout = buf
-
-		cmd.Run()
-		out = buf.Bytes()
-	}
-
-	md5 := md5.Sum(out)
-	md5str := hex.EncodeToString(md5[:])
-
-	if val, ok := clipboardhistory[md5str]; ok {
-		val.Time = time.Now()
-	} else {
-		cmd := exec.Command("identify", "-format", "%m", "-")
-		cmd.Stdin = bytes.NewReader(out)
-
-		res, err := cmd.CombinedOutput()
-		if err != nil {
-			slog.Error(Name, "update image", err, "msg", res)
-			return
-		}
-
-		ext := strings.ToLower(string(res))
-		ext = strings.TrimSpace(ext)
-
-		if file := saveImg(out, ext); file != "" {
-			clipboardhistory[md5str] = &Item{
-				Img:   file,
-				Time:  time.Now(),
-				State: StateEditable,
-			}
-		}
-	}
-
-	saveFileChan <- struct{}{}
-}
-
-// ... returns false if its an image from browser
-func updateText(text string) bool {
-	if strings.TrimSpace(text) == "" {
-		return true
-	}
-
-	if config.IgnoreSymbols {
-		if _, ok := symbols[text]; ok {
-			return true
-		}
-	}
-
-	mt := getMimetypes()
-
-	if slices.Contains(mt, "text/_moz_htmlcontext") || slices.Contains(mt, "chromium/x-source-url") {
-		for k := range imgTypes {
-			if slices.Contains(mt, k) {
-				return false
-			}
-		}
-	}
-
-	isURIList := false
-
-	for _, v := range mt {
-		if slices.Contains(ignoreMimetypes, v) {
-			return true
-		}
-
-		if v == "text/uri-list" {
-			isURIList = true
-		}
-	}
-
-	uris := []string{}
-
-	if isURIList {
-		for v := range strings.FieldsSeq(text) {
-			if strings.HasPrefix(v, "file://") {
-				uris = append(uris, v)
-			} else {
-				uris = append(uris, fmt.Sprintf("file://%s", v))
-			}
-		}
-
-		text = strings.Join(uris, "\n")
-	}
-
-	b := []byte(text)
-	md5 := md5.Sum(b)
-	md5str := hex.EncodeToString(md5[:])
-
-	if val, ok := clipboardhistory[md5str]; ok {
-		val.Time = time.Now()
-	} else {
-		if !utf8.Valid(b) {
-			slog.Error(Name, "updating", "string content contains invalid UTF-8")
-		}
-
-		if isURIList {
-			clipboardhistory[md5str] = &Item{
-				URIList: uris,
-				Time:    time.Now(),
-			}
-		} else {
-			clipboardhistory[md5str] = &Item{
-				Content: text,
-				Time:    time.Now(),
-				State:   StateEditable,
-			}
-		}
-	}
-
-	saveFileChan <- struct{}{}
-	return true
 }
 
 func trim() {
@@ -543,7 +256,8 @@ func saveImg(b []byte, ext string) string {
 
 	outfile, err := os.Create(file)
 	if err != nil {
-		panic(err)
+		slog.Error(Name, "create image file", err)
+		return ""
 	}
 	defer outfile.Close()
 
@@ -565,360 +279,12 @@ func PrintDoc(write bool) {
 	util.PrintConfig(config, Name, write)
 }
 
-const (
-	ActionPause      = "pause"
-	ActionPin        = "pin"
-	ActionUnpin      = "unpin"
-	ActionLocalsend  = "localsend"
-	ActionUnpause    = "unpause"
-	ActionCopy       = "copy"
-	ActionEdit       = "edit"
-	ActionRemove     = "remove"
-	ActionRemoveAll  = "remove_all"
-	ActionImagesOnly = "show_images_only"
-	ActionTextOnly   = "show_text_only"
-	ActionPinnedOnly = "show_pinned_only"
-	ActionCombined   = "show_combined"
-)
-
-func Activate(single bool, identifier, action string, query string, args string, format uint8, conn net.Conn) {
-	if action == "" {
-		action = ActionCopy
-	}
-
-	switch action {
-	case ActionLocalsend:
-		item := clipboardhistory[identifier]
-
-		var path string
-
-		if item.Img != "" {
-			path = item.Img
-		} else {
-			f, err := os.CreateTemp(os.TempDir(), "clipboard_*.txt")
-			if err != nil {
-				slog.Error(Name, "actionlocalsend", err)
-			}
-
-			_, err = f.WriteString(item.Content)
-			if err != nil {
-				slog.Error(Name, "actionlocalsend", err)
-			}
-
-			path = f.Name()
-		}
-
-		cmd := exec.Command("sh", "-c", strings.TrimSpace(fmt.Sprintf("%s %s %s", common.LaunchPrefix(), "localsend", path)))
-
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Setsid: true,
-		}
-
-		err := cmd.Start()
-		if err != nil {
-			slog.Error(Name, "actionlocalsend", err)
-		} else {
-			go func() {
-				cmd.Wait()
-			}()
-		}
-	case ActionPause:
-		paused.Store(true)
-	case ActionUnpause:
-		paused.Store(false)
-	case ActionImagesOnly, ActionTextOnly, ActionPinnedOnly, ActionCombined:
-		currentMode = action
-	case ActionEdit:
-		item := clipboardhistory[identifier]
-		if item.State != StateEditable {
-			return
-		}
-
-		if item.Img != "" {
-			if config.ImageEditorCmd == "" {
-				slog.Info(Name, "edit", "image_editor not set")
-				return
-			}
-
-			toRun := strings.ReplaceAll(config.ImageEditorCmd, "%FILE%", item.Img)
-
-			cmd := exec.Command("sh", "-c", toRun)
-
-			err := cmd.Start()
-			if err != nil {
-				slog.Error(Name, "openedit", err)
-				return
-			} else {
-				go func() {
-					cmd.Wait()
-				}()
-			}
-
-			return
-		}
-
-		tmpFile, err := os.CreateTemp("", "*.txt")
-		if err != nil {
-			slog.Error(Name, "edit", err)
-			return
-		}
-
-		tmpFile.Write([]byte(item.Content))
-
-		var run string
-
-		if config.TextEditorCmd != "" {
-			run = strings.ReplaceAll(config.TextEditorCmd, "%FILE%", tmpFile.Name())
-		} else {
-			run = fmt.Sprintf("xdg-open file://%s", tmpFile.Name())
-
-			if common.ForceTerminalForFile(tmpFile.Name()) {
-				run = common.WrapWithTerminal(run)
-			}
-		}
-
-		cmd := exec.Command("sh", "-c", run)
-		err = cmd.Start()
-		if err != nil {
-			slog.Error(Name, "openedit", err)
-			return
-		} else {
-			cmd.Wait()
-
-			b, _ := os.ReadFile(tmpFile.Name())
-			item.Content = string(b)
-			saveToFile()
-		}
-	case ActionRemove:
-		mu.Lock()
-
-		if _, ok := clipboardhistory[identifier]; ok {
-			if clipboardhistory[identifier].Img != "" {
-				_ = os.Remove(clipboardhistory[identifier].Img)
-			}
-
-			delete(clipboardhistory, identifier)
-
-			if len(clipboardhistory) != 0 {
-				setupModes()
-
-				if !slices.Contains(availableModes, currentMode) {
-					currentMode = ActionCombined
-				}
-			}
-
-			saveToFile()
-		}
-
-		mu.Unlock()
-	case ActionUnpin:
-		mu.Lock()
-
-		if val, ok := clipboardhistory[identifier]; ok {
-			val.Pinned = false
-
-			saveToFile()
-		}
-
-		setupModes()
-
-		mu.Unlock()
-	case ActionPin:
-		mu.Lock()
-
-		if val, ok := clipboardhistory[identifier]; ok {
-			val.Pinned = true
-
-			saveToFile()
-		}
-
-		if !slices.Contains(availableModes, ActionPinnedOnly) {
-			availableModes = append(availableModes, ActionPinnedOnly)
-		}
-
-		mu.Unlock()
-	case ActionRemoveAll:
-		mu.Lock()
-
-		for k, v := range clipboardhistory {
-			if v.Pinned {
-				continue
-			}
-
-			delete(clipboardhistory, k)
-
-			if v.Img != "" {
-				_ = os.Remove(v.Img)
-			}
-		}
-
-		saveToFile()
-		currentMode = ActionCombined
-		setupModes()
-		mu.Unlock()
-	case ActionCopy:
-		cmd := exec.Command("sh", "-c", config.Command)
-
-		item := clipboardhistory[identifier]
-		if item.Img != "" {
-			f, _ := os.ReadFile(item.Img)
-			cmd.Stdin = bytes.NewReader(f)
-		} else {
-			if len(item.URIList) > 0 {
-				withMimetype := fmt.Sprintf("%s -t 'text/uri-list'", config.Command)
-				cmd = exec.Command("sh", "-c", withMimetype)
-
-				uriList := strings.Join(item.URIList, "\n")
-				cmd.Stdin = strings.NewReader(uriList)
-			} else {
-				cmd.Stdin = strings.NewReader(item.Content)
-			}
-		}
-
-		err := cmd.Start()
-		if err != nil {
-			slog.Error("clipboard", "activate", err)
-			return
-		} else {
-			go func() {
-				cmd.Wait()
-			}()
-		}
-	default:
-		slog.Error(Name, "activate", fmt.Sprintf("unknown action: %s", action))
-		return
-	}
-}
-
-func Query(conn net.Conn, query string, _ bool, exact bool, _ uint8) []*pb.QueryResponse_Item {
-	entries := []*pb.QueryResponse_Item{}
-
-	for k, v := range clipboardhistory {
-		switch currentMode {
-		case ActionPinnedOnly:
-			if !v.Pinned {
-				continue
-			}
-		case ActionImagesOnly:
-			if v.Img == "" {
-				continue
-			}
-		case ActionTextOnly:
-			if v.Img != "" {
-				continue
-			}
-		}
-
-		actions := []string{ActionCopy, ActionEdit}
-
-		if v.Pinned {
-			actions = append(actions, ActionUnpin)
-		} else {
-			actions = append(actions, ActionPin, ActionRemove)
-		}
-
-		if hasLocalsend {
-			actions = append(actions, ActionLocalsend)
-		}
-
-		state := []string{}
-
-		if v.Pinned {
-			state = append(state, "pinned")
-		}
-
-		content := v.Content
-
-		isURIList := false
-
-		if len(v.URIList) > 0 {
-			isURIList = true
-			files := []string{}
-
-			for _, v := range v.URIList {
-				files = append(files, filepath.Base(v))
-			}
-
-			content = strings.Join(files, ",")
-		}
-
-		if len([]rune(content)) > 1000 {
-			content = string([]rune(content)[:1000])
-		}
-
-		e := &pb.QueryResponse_Item{
-			Identifier: k,
-			Text:       content,
-			Subtext:    v.Time.Format(time.RFC1123Z),
-			Type:       pb.QueryResponse_REGULAR,
-			State:      state,
-			Actions:    actions,
-			Provider:   Name,
-		}
-
-		if v.Img != "" {
-			e.Preview = v.Img
-			e.PreviewType = util.PreviewTypeFile
-		} else {
-			if isURIList {
-				if len(v.URIList) == 1 {
-					e.Preview = v.URIList[0]
-					e.PreviewType = util.PreviewTypeFile
-				} else {
-					e.Preview = strings.Join(v.URIList, "\n")
-					e.PreviewType = util.PreviewTypeText
-				}
-			} else {
-				e.Preview = v.Content
-				e.PreviewType = util.PreviewTypeText
-			}
-		}
-
-		if query != "" {
-			score, pos, start := common.FuzzyScore(query, v.Content, exact)
-
-			e.Score = score
-			e.Fuzzyinfo = &pb.QueryResponse_Item_FuzzyInfo{
-				Field:     "text",
-				Positions: pos,
-				Start:     start,
-			}
-
-			if e.Score > config.MinScore {
-				entries = append(entries, e)
-			}
-		} else {
-			entries = append(entries, e)
-		}
-	}
-
-	if query == "" {
-		slices.SortStableFunc(entries, func(a, b *pb.QueryResponse_Item) int {
-			ta, _ := time.Parse(time.RFC1123Z, a.Subtext)
-			tb, _ := time.Parse(time.RFC1123Z, b.Subtext)
-
-			return ta.Compare(tb) * -1
-		})
-
-		for k, v := range entries {
-			if slices.Contains(v.State, "pinned") && config.PinnedOnTop {
-				entries[k].Score = int32(1_000_000_000 - k)
-			} else {
-				entries[k].Score = int32(1_000_000 - k)
-			}
-		}
-	}
-
-	return entries
-}
-
 func getMimetypes() []string {
 	cmd := exec.Command("wl-paste", "--list-types")
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Println(err)
-		log.Println(string(out))
+		slog.Error(Name, "getMimetypes", err, "output", string(out))
 		return []string{}
 	}
 

--- a/internal/providers/clipboard/types.go
+++ b/internal/providers/clipboard/types.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	_ "embed"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/abenz1267/elephant/v2/pkg/common"
+)
+
+var (
+	Name             = "clipboard"
+	NamePretty       = "Clipboard"
+	file             = common.CacheFile("clipboard.gob")
+	imgTypes         = make(map[string]string)
+	config           *Config
+	clipboardhistory = make(map[string]*Item)
+	mu               sync.Mutex
+	availableModes   = []string{}
+	currentMode      = ActionCombined
+	hasLocalsend     bool
+)
+
+//go:embed README.md
+var readme string
+
+//go:embed data/UnicodeData.txt
+var unicodedata string
+
+//go:embed data/symbols.xml
+var symbolsdata string
+
+var (
+	paused       atomic.Bool
+	saveFileChan = make(chan struct{})
+)
+
+const StateEditable = "editable"
+
+type Item struct {
+	Content string
+	Img     string
+	URIList []string
+	Time    time.Time
+	State   string
+	Pinned  bool
+}
+
+type Config struct {
+	common.Config  `koanf:",squash"`
+	MaxItems       int    `koanf:"max_items" desc:"max amount of clipboard history items" default:"100"`
+	OCR            bool   `koanf:"ocr" desc:"extract text from images via tesseract" default:"false"`
+	ImageEditorCmd string `koanf:"image_editor_cmd" desc:"editor to use for images. use '%FILE%' as placeholder for file path." default:""`
+	TextEditorCmd  string `koanf:"text_editor_cmd" desc:"editor to use for text, otherwise default for mimetype. use '%FILE%' as placeholder for file path." default:""`
+	Command        string `koanf:"command" desc:"default command to be executed" default:"wl-copy"`
+	IgnoreSymbols  bool   `koanf:"ignore_symbols" desc:"ignores symbols/unicode" default:"true"`
+	PinnedOnTop    bool   `koanf:"pinned_on_top" desc:"put pinned items on top" default:"false"`
+	AutoCleanup    int    `koanf:"auto_cleanup" desc:"will automatically cleanup entries entries older than X minutes" default:"0"`
+}
+
+var symbols = make(map[string]struct{})
+
+const (
+	ActionPause      = "pause"
+	ActionPin        = "pin"
+	ActionUnpin      = "unpin"
+	ActionLocalsend  = "localsend"
+	ActionUnpause    = "unpause"
+	ActionCopy       = "copy"
+	ActionEdit       = "edit"
+	ActionRemove     = "remove"
+	ActionRemoveAll  = "remove_all"
+	ActionImagesOnly = "show_images_only"
+	ActionTextOnly   = "show_text_only"
+	ActionPinnedOnly = "show_pinned_only"
+	ActionCombined   = "show_combined"
+)
+
+var ignoreMimetypes = []string{"x-kde-passwordManagerHint"}


### PR DESCRIPTION
Adds tesseract-based OCR extraction for clipboard images, enabled via the `ocr` config flag in clipboard.toml.

Also refactors the clipboard provider from a single 650-line setup.go into separate files (types, clipboard, ocr) and fixes a few pre-existing bugs:
- IgnoreSymbols config option actually works now (initUnicodeSymbols was never called)
- Fixed data races in cleanup/saveToFile/trim (map access without mutex)
- saveImg no longer panics on file errors
- Replaced log.Println with slog for consistency

Closes #208