### PR TITLE
fix(clipboard): prioritize image MIME types over text when both present

### DIFF
--- a/internal/providers/clipboard/clipboard.go
+++ b/internal/providers/clipboard/clipboard.go
@@ -90,6 +90,15 @@ func getClipboardText() (string, error) {
 	return string(out), err
 }
 
+func hasImageType(mt []string) bool {
+	for _, m := range mt {
+		if _, ok := imgTypes[m]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 func updateImage(out []byte) {
 	mt := getMimetypes()
 
@@ -139,6 +148,12 @@ func updateImage(out []byte) {
 }
 
 func updateText(text string) bool {
+	mt := getMimetypes()
+
+	if hasImageType(mt) {
+		return false
+	}
+
 	if strings.TrimSpace(text) == "" {
 		return true
 	}
@@ -146,16 +161,6 @@ func updateText(text string) bool {
 	if config.IgnoreSymbols {
 		if _, ok := symbols[text]; ok {
 			return true
-		}
-	}
-
-	mt := getMimetypes()
-
-	if slices.Contains(mt, "text/_moz_htmlcontext") || slices.Contains(mt, "chromium/x-source-url") {
-		for k := range imgTypes {
-			if slices.Contains(mt, k) {
-				return false
-			}
 		}
 	}
 

--- a/internal/providers/clipboard/setup.go
+++ b/internal/providers/clipboard/setup.go
@@ -30,7 +30,7 @@ func Setup() {
 	imgTypes["image/png"] = "png"
 	imgTypes["image/jpg"] = "jpg"
 	imgTypes["image/jpeg"] = "jpeg"
-	imgTypes["image/webm"] = "webm"
+	imgTypes["image/webp"] = "webp"
 
 	ls, err := exec.LookPath("localsend")
 	if ls != "" && err == nil {


### PR DESCRIPTION
## Bug

AI-generated images copied from the browser enter Wayland's clipboard with 20+ mixed MIME types (image/png, text/ico, application/ico, etc.). The program was not saving the image because it always tried to read text first: `wl-paste -t text` returned empty string, `updateText()` returned `true` (empty text is OK), and the image path was never reached.

Confirmed via debug: `wl-paste -t image/png` returns the 1MB PNG correctly.

## Root Cause

- `handleChange()` always tries text first; empty text is accepted as valid
- `updateText()` guard only caught images with browser-specific markers (`text/_moz_htmlcontext` / `chromium/x-source-url`)
- AI-generated images don't carry those markers, so the guard never fired
- `image/webp` was also missing from `imgTypes` (was registered as `image/webm`, a video format)

## Fix

1. **New `hasImageType()` helper** — uses `imgTypes` map as single source of truth (DRY)
2. **Moved image MIME check before empty-text guard in `updateText()`** — if image MIME types exist, `updateText()` returns `false`, causing `handleChange()` to fall through to the image path
3. **Replaced browser-specific Firefox/Chromium guard** with the generic `hasImageType()` check
4. **Fixed typo** `image/webm` → `image/webp` in `imgTypes`

## Testing

- `go vet ./internal/providers/clipboard/` passes
- Manual confirmation: `wl-paste -t image/png` works on the reported clipboard content