### PR TITLE
fix(doc): filter empty slice keys from generated TOML config

### DIFF
--- a/internal/util/doc.go
+++ b/internal/util/doc.go
@@ -82,7 +82,14 @@ func PrintConfig(c any, name string, write bool) {
 			return
 		}
 
-		b, err := toml.Marshal(k.Raw())
+		raw := k.Raw()
+		for key, val := range raw {
+			if v, ok := val.([]any); ok && len(v) == 0 {
+				delete(raw, key)
+			}
+		}
+
+		b, err := toml.Marshal(raw)
 		if err != nil {
 			slog.Error("printconfig", "marshall config", err)
 			return


### PR DESCRIPTION
When running `elephant g config`, provider config files contained `entries = []` for empty slice struct fields. This plain TOML array is incompatible with the `[[entries]]` array-of-tables syntax that users add to configure search engines, causing:

```
ERROR websearch config="toml: key value already exists as a entries, but should be an array table"
```

Filter out zero-length slices from the raw map before marshaling to TOML, so empty slices are omitted entirely from generated config files.

Fixes #273