### PR TITLE
fix(doc): create config directory before writing files

### DIFF
--- a/internal/util/doc.go
+++ b/internal/util/doc.go
@@ -94,7 +94,11 @@ func PrintConfig(c any, name string, write bool) {
 		}
 
 		file := filepath.Join(dir, fmt.Sprintf("%s.toml", name))
-
+		err = os.MkdirAll(dir, 0o755)
+		if err != nil {
+			slog.Error("printconfig", "create config dir", err)
+			return
+		}
 		err = os.WriteFile(file, b, 0o644)
 		if err != nil {
 			slog.Error("printconfig", "write config", err)


### PR DESCRIPTION
When running `elephant g config` without an existing `~/.config/elephant/` directory, `os.WriteFile` fails with `ENOENT` because the parent directory doesn't exist.

Add `os.MkdirAll` before `WriteFile` to ensure the config directory is created if it doesn't exist yet.

Fixes #272