### PR TITLE
fix(menus): add HideNamePrettyPrefix opt-out for global context prefix

### DIFF
--- a/internal/providers/menus/setup.go
+++ b/internal/providers/menus/setup.go
@@ -221,7 +221,7 @@ func Activate(single bool, identifier, action string, query string, args string,
 		}
 
 		if slices.Contains(menu.AsyncActions, action) {
-			updated := itemToEntry(format, query, conn, menu.Actions, menu.NamePretty, single, menu.Icon, &e)
+			updated := itemToEntry(format, query, conn, menu.Actions, menu.NamePretty, single, menu.Icon, menu.HideNamePrettyPrefix, &e)
 			handlers.UpdateItem(format, query, conn, updated)
 
 		}
@@ -276,7 +276,7 @@ func Query(conn net.Conn, query string, single bool, exact bool, format uint8) [
 				continue
 			}
 
-			e := itemToEntry(format, query, conn, v.Actions, v.NamePretty, single, v.Icon, &v.Entries[k])
+			e := itemToEntry(format, query, conn, v.Actions, v.NamePretty, single, v.Icon, v.HideNamePrettyPrefix, &v.Entries[k])
 
 			if v.FixedOrder {
 				e.Score = 1_000_000 - int32(k)
@@ -367,7 +367,7 @@ func calcScore(query string, haystack []string, exact bool) (string, int32, []in
 	return match, scoreRes, posRes, startRes, true
 }
 
-func itemToEntry(format uint8, query string, conn net.Conn, menuActions map[string]string, namePretty string, single bool, icon string, me *common.Entry) *pb.QueryResponse_Item {
+func itemToEntry(format uint8, query string, conn net.Conn, menuActions map[string]string, namePretty string, single bool, icon string, hideNamePrettyPrefix bool, me *common.Entry) *pb.QueryResponse_Item {
 	if me.Icon != "" {
 		icon = me.Icon
 	}
@@ -377,7 +377,7 @@ func itemToEntry(format uint8, query string, conn net.Conn, menuActions map[stri
 	if !single {
 		if sub == "" {
 			sub = namePretty
-		} else {
+		} else if !hideNamePrettyPrefix {
 			sub = fmt.Sprintf("%s: %s", namePretty, sub)
 		}
 	}

--- a/pkg/common/menucfg.go
+++ b/pkg/common/menucfg.go
@@ -54,6 +54,7 @@ type Menu struct {
 	MinScore             int32             `toml:"min_score" desc:"minimum score for items to be displayed" default:"depends on provider"`
 	Parent               string            `toml:"parent" desc:"defines the parent menu" default:""`
 	SubMenu              string            `toml:"submenu" desc:"defines submenu to trigger on activation" default:""`
+	HideNamePrettyPrefix bool              `toml:"hide_name_pretty_prefix" desc:"if true, dont prefix with name_pretty in global context" default:"false"`
 
 	// internal
 	LuaString string


### PR DESCRIPTION
Closes #267

## Summary
- Adds `hide_name_pretty_prefix` field to Entry struct in menu provider
- When set to `true`, the `NamePretty: ` prefix is suppressed in global context

## Changes

| File | Change |
|------|--------|
| `pkg/common/menucfg.go` | Added `HideNamePrettyPrefix bool` to `Entry` struct |
| `internal/providers/menus/setup.go` | Check `HideNamePrettyPrefix` before prepending `NamePretty` to `Subtext` |

## Test Plan
- [x] Build passes (`go build ./cmd/elephant/`)
- [x] `go vet` passes on affected packages