### PR TITLE
feat(desktopapplications): expose X-Flatpak and X-SnapInstanceName as item state

### DIFF
--- a/internal/providers/desktopapplications/parser.go
+++ b/internal/providers/desktopapplications/parser.go
@@ -12,22 +12,24 @@ import (
 )
 
 type Data struct {
-	NoDisplay      bool
-	Hidden         bool
-	Terminal       bool
-	Action         string
-	Exec           string
-	Name           string
-	Comment        string
-	Path           string
-	Parent         string
-	GenericName    string
-	StartupWMClass string
-	Icon           string
-	Categories     []string
-	OnlyShowIn     []string
-	NotShowIn      []string
-	Keywords       []string
+	NoDisplay         bool
+	Hidden            bool
+	Terminal          bool
+	Action            string
+	Exec              string
+	Name              string
+	Comment           string
+	Path              string
+	Parent            string
+	GenericName       string
+	StartupWMClass    string
+	Icon              string
+	Categories        []string
+	OnlyShowIn        []string
+	NotShowIn         []string
+	Keywords          []string
+	XFlatpak          string
+	XSnapInstanceName string
 }
 
 func parseFile(path, l, ll string) (*DesktopFile, error) {
@@ -170,6 +172,10 @@ func parseData(in []byte, l, ll string) Data {
 			}
 
 			res.Exec = exec
+		case bytes.HasPrefix(line, []byte("X-Flatpak=")):
+			res.XFlatpak = string(bytes.TrimPrefix(line, []byte("X-Flatpak=")))
+		case bytes.HasPrefix(line, []byte("X-SnapInstanceName=")):
+			res.XSnapInstanceName = string(bytes.TrimPrefix(line, []byte("X-SnapInstanceName=")))
 		case bytes.Contains(line, []byte("[Desktop Action ")):
 			res.Action = string(bytes.TrimPrefix(line, []byte("[Desktop Action ")))
 			res.Action = strings.TrimSuffix(res.Action, "]")

--- a/internal/providers/desktopapplications/query.go
+++ b/internal/providers/desktopapplications/query.go
@@ -122,6 +122,13 @@ func Query(conn net.Conn, query string, _ bool, exact bool, _ uint8) []*pb.Query
 					state = append(state, "unpinned")
 				}
 
+				if v.XFlatpak != "" {
+					state = append(state, "flatpak")
+				}
+				if v.XSnapInstanceName != "" {
+					state = append(state, "snap")
+				}
+
 				pinsMu.RLock()
 				if slices.Contains(pins, k) {
 					a = append(a, ActionUnpin)
@@ -247,6 +254,13 @@ func Query(conn net.Conn, query string, _ bool, exact bool, _ uint8) []*pb.Query
 
 						if usageScore != 0 {
 							state = append(state, "history")
+						}
+
+						if v.XFlatpak != "" {
+							state = append(state, "flatpak")
+						}
+						if v.XSnapInstanceName != "" {
+							state = append(state, "snap")
 						}
 
 						pinsMu.RLock()


### PR DESCRIPTION
Closes #263

## Summary
- Parses `X-Flatpak` and `X-SnapInstanceName` from .desktop files
- Adds `"flatpak"` or `"snap"` to the item's `State` slice when present
- Allows users to visually distinguish Flatpak, Snap, and native apps in Walker

## Changes

| File | Change |
|------|--------|
| `internal/providers/desktopapplications/parser.go` | Added `XFlatpak` and `XSnapInstanceName` to `Data` struct + parsing |
| `internal/providers/desktopapplications/query.go` | Append source type to `State` for both main entries and actions |

## Test Plan
- [x] Build passes (`go build ./cmd/elephant/`)
- [x] `go vet` passes on affected packages