### PR TITLE
fix(files): correct malformed fd_flags default in config docs

### DIFF
--- a/internal/providers/files/setup.go
+++ b/internal/providers/files/setup.go
@@ -44,7 +44,7 @@ type Config struct {
 	IgnorePreviews []IgnoredPreview `koanf:"ignore_previews" desc:"paths will not have a preview" default:""`
 	IgnoreWatching []string         `koanf:"ignore_watching" desc:"paths will not be watched" default:""`
 	SearchDirs     []string         `koanf:"search_dirs" desc:"directories to search for files" default:"$HOME"`
-	FdFlags        []string         `koanf:"fd_flags" desc:"flags for fd" default:"['--ignore-vcs', '--type,' ,'file', '--type,' 'directory']"`
+	FdFlags        []string         `koanf:"fd_flags" desc:"flags for fd" default:"['--ignore-vcs', '--type', 'file', '--type', 'directory']"`
 	WatchBuffer    int              `koanf:"watch_buffer" desc:"time in millisecnds elephant will gather changed paths before processing them" default:"2000"`
 	WatchDirs      []string         `koanf:"watch_dirs" desc:"watch these dirs, even if watch = false" default:"[]"`
 	Watch          bool             `koanf:"watch" desc:"watch indexed directories" default:"false"`


### PR DESCRIPTION
## Summary

The `default` struct tag for `fd_flags` is malformed — the commas sit **inside** the quotes rather than between the elements:

```go
default:"['--ignore-vcs', '--type,' ,'file', '--type,' 'directory']"
```

This is user-visible, because config documentation is generated from these tags. `elephant generate doc` currently emits:

```
|fd_flags|[]string|['--ignore-vcs', '--type,' ,'file', '--type,' 'directory']|flags for fd|
```

It also disagrees with the actual runtime default set a few lines below in `LoadConfig()`:

```go
FdFlags: []string{"--ignore-vcs", "--type", "file", "--type", "directory"},
```

This PR makes the documented default match the real one. No behaviour change.

## Why it's worth fixing

Anyone configuring `fd_flags` naturally starts from the documented default. Copying it yields literal `--type,` arguments, which `fd` rejects with exit status 2.

The failure mode is quiet. `index()` streams `fd`'s stdout and only checks the exit status at the very end:

```go
if err := cmd.Wait(); err != nil {
    slog.Error(Name, "cmd wait", err)
}
```

When `fd` exits non-zero the scanner has already finished with nothing to read, so every path is dropped and the index ends up containing only the `search_dirs` entries written earlier in the function. The provider looks healthy — it starts fine and queries return instantly — and the sole clue is one `cmd wait` line in the log.

The same trap catches anyone who writes `fd_flags` as a space-separated string instead of a TOML array. Since it's a `[]string`, koanf loads the whole string as a single argv entry and `fd` rejects it identically. That's arguably worth a line in the docs too, though I've kept this PR to the one-line fix.

## Test plan

- [x] `elephant generate doc` now prints `['--ignore-vcs', '--type', 'file', '--type', 'directory']`
- [x] Documented default now matches the `LoadConfig()` default verbatim
- [x] Tag-only change; no runtime behaviour affected
