### PR TITLE
fix(clipboard): avoid deadlock when saving actions

### DIFF
--- a/internal/providers/clipboard/clipboard.go
+++ b/internal/providers/clipboard/clipboard.go
@@ -465,7 +465,7 @@ func Activate(single bool, identifier, action string, query string, args string,
 				}
 			}
 
-			saveToFile()
+			saveToFileLocked()
 		}
 
 		mu.Unlock()
@@ -475,7 +475,7 @@ func Activate(single bool, identifier, action string, query string, args string,
 		if val, ok := clipboardhistory[identifier]; ok {
 			val.Pinned = false
 
-			saveToFile()
+			saveToFileLocked()
 		}
 
 		setupModes()
@@ -487,7 +487,7 @@ func Activate(single bool, identifier, action string, query string, args string,
 		if val, ok := clipboardhistory[identifier]; ok {
 			val.Pinned = true
 
-			saveToFile()
+			saveToFileLocked()
 		}
 
 		if !slices.Contains(availableModes, ActionPinnedOnly) {
@@ -510,7 +510,7 @@ func Activate(single bool, identifier, action string, query string, args string,
 			}
 		}
 
-		saveToFile()
+		saveToFileLocked()
 		currentMode = ActionCombined
 		setupModes()
 		mu.Unlock()


### PR DESCRIPTION
## Summary
- use `saveToFileLocked` for clipboard mutation actions that already hold `mu`
- prevent remove, pin, unpin, and remove-all from deadlocking subsequent clipboard queries
- keep `saveToFile` unchanged for callers that do not already hold the mutex

## Testing
- `nix develop -c go test ./internal/providers/clipboard`
- `nix develop -c go test ./...`
- manually verified repeated pin/unpin actions followed by fresh clipboard queries through Walker

🤖 Generated with [ECA](https://eca.dev) (openai/gpt-5.6-sol)